### PR TITLE
Fixing test by getting `to_mention` in scope for all usages

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -215,13 +215,13 @@ def choose_reviewer(repo, owner, diff, exclude, config):
 
 
     most_changed = None
+    to_mention = []
     # If there's directories with specially assigned groups/users
     # inspect the diff to find the directory (under src) with the most
     # additions
     if dirs:
         counts = {}
         cur_dir = None
-        to_mention = []
         for line in diff.split('\n'):
             if line.startswith("diff --git "):
                 # update cur_dir


### PR DESCRIPTION
Unit tests currently fail.
```
$ nosetests
.E.
======================================================================
ERROR: highfive.tests.test_newpr.TestNewPR.test_choose_reviewer
----------------------------------------------------------------------
_StringException: Traceback (most recent call last):
  File "/Users/davidalber/dev/highfive/highfive/tests/test_newpr.py", line 22, in test_choose_reviewer
    fake_config)
  File "/Users/davidalber/dev/highfive/highfive/newpr.py", line 292, in choose_reviewer
    for mention in to_mention:
UnboundLocalError: local variable 'to_mention' referenced before assignment


----------------------------------------------------------------------
Ran 3 tests in 0.139s

FAILED (errors=1)
```

This PR fixes the broken test.

I also recommend someone enable Travis CI on this repository at https://travis-ci.org/rust-lang-nursery/highfive.