### PR TITLE
Fix unavailable diff when working with private repos

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -350,7 +350,10 @@ def new_pr(payload, user, token):
 
     author = payload["pull_request"]['user']['login']
     issue = str(payload["number"])
-    diff = api_req("GET", payload["pull_request"]["diff_url"])['body']
+    diff = api_req(
+        "GET", payload["pull_request"]["url"], None, user, token,
+        "application/vnd.github.v3.diff",
+    )['body']
 
     msg = payload["pull_request"]['body']
     reviewer = find_reviewer(msg)


### PR DESCRIPTION
Before this PR, highfive fetched the PR diff from the URL provided by the webhook, which is `https://github.com/org/repo/pull/42.diff`.

That works fine for public repos, but for private repos that URL is private, and highfive can't fetch it. This commit changes the code to properly fetch the diff [from the API](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests).

(found this while working on another PR and testing it on a private test repo)