### PR TITLE
Add support for automatically labelling new PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ It should look like:
         "dirname":  ["subteamname", "@anotheruser"]
     },
     "contributing": "http://project.tld/contributing_guide.html",
-    "expected_branch": "develop"
-}   
+    "expected_branch": "develop",
+    "new_pr_labels": ["S-waiting-for-review"]
+}
 ```
 
 The `groups` section allows you to alias lists of usernames. You should
@@ -66,6 +67,9 @@ If PRs should be filed against a branch other than `master`, specify the
 correct destination in the `expected_branch` field. If `expected_branch` is
 left out, highfive will assume that PRs should be filed against `master`. 
 The bot posts a warning on any PR that targets an unexpected branch.
+
+`new_pr_labels` contains a list of labels to apply to each new PR. If it's left
+out or empty, no new labels will be applied.
 
 Enabling a Repo
 ---------------

--- a/highfive/configs/rust.json
+++ b/highfive/configs/rust.json
@@ -45,5 +45,6 @@
     "contributors": [
         "Aatch",
         "lifthrasiir"
-    ]
+    ],
+    "new_pr_labels": ["S-waiting-on-review"]
 }

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -23,6 +23,7 @@ contributors_url = "https://api.github.com/repos/%s/%s/contributors?per_page=100
 post_comment_url = "https://api.github.com/repos/%s/%s/issues/%s/comments"
 collabo_url = "https://api.github.com/repos/%s/%s/collaborators"
 issue_url = "https://api.github.com/repos/%s/%s/issues/%s"
+issue_labels_url = "https://api.github.com/repos/%s/%s/issues/%s/labels"
 
 welcome_with_reviewer = '@%s (or someone else)'
 welcome_without_reviewer = "@nrc (NB. this repo may be misconfigured)"
@@ -139,6 +140,17 @@ def get_collaborators(owner, repo, user, token):
         else:
             raise e
     return [c['login'] for c in json.loads(result)]
+
+
+def add_labels(labels, owner, repo, issue, user, token):
+    try:
+        result = api_req("POST", issue_labels_url % (owner, repo, issue), labels, user, token)
+    except urllib2.HTTPError, e:
+        if e.code == 201:
+            pass
+        else:
+            raise e
+
 
 # This function is adapted from https://github.com/kennethreitz/requests/blob/209a871b638f85e2c61966f82e547377ed4260d9/requests/utils.py#L562
 # Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
@@ -385,6 +397,9 @@ def new_pr(payload, user, token):
 
     if warnings:
         post_comment(warning_summary % '\n'.join(map(lambda x: '* ' + x, warnings)), owner, repo, issue, user, token)
+
+    if "new_pr_labels" in config and config["new_pr_labels"]:
+        add_labels(config["new_pr_labels"], owner, repo, issue, user, token)
 
 
 def new_comment(payload, user, token):


### PR DESCRIPTION
Now that bors automatically applies the right labels when it interacts with PRs, the only thing left to automate is applying the labels when a new PR is created.

This PR adds supports for this in highfive, with the new `new_pr_labels` configuration key, and adds it to the rust-lang/rust repo (the `S-waiting-on-review` label will be applied).

cc @nrc