### PR TITLE
Adding more unit tests for `choose_reviewer`

### DIFF
--- a/highfive/tests/base.py
+++ b/highfive/tests/base.py
@@ -4,8 +4,8 @@ import testtools
 
 
 class BaseTest(testtools.TestCase):
-
-    def _load_fake(self, fake):
+    @classmethod
+    def _load_fake(cls, fake):
         fakes_dir = os.path.join(os.path.dirname(__file__), 'fakes')
 
         with open(os.path.join(fakes_dir, fake)) as fake:

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -1,8 +1,11 @@
+from copy import deepcopy
 from highfive import newpr
 from highfive.tests import base
 
 class TestNewPR(base.BaseTest):
+    pass
 
+class TestSubmodule(TestNewPR):
     def test_submodule(self):
         submodule_diff = self._load_fake('submodule.diff')
         self.assertTrue(newpr.modifies_submodule(submodule_diff))
@@ -10,14 +13,92 @@ class TestNewPR(base.BaseTest):
         normal_diff = self._load_fake('normal.diff')
         self.assertFalse(newpr.modifies_submodule(normal_diff))
 
+class TestChooseReviewer(TestNewPR):
+    @classmethod
+    def setUpClass(cls):
+        cls.diff = {
+            'normal': cls._load_fake('normal.diff'),
+        }
+        cls.config = {
+            'individuals_no_dirs' :{
+                "groups": { "all": ["@pnkfelix", "@nrc"] },
+                "dirs": {},
+            }
+        }
 
-    def test_choose_reviewer(self):
-        normal_diff = self._load_fake('normal.diff')
-        fake_config = { "groups": {"all":["@pnkfelix", "@nrc"]}, 
-                        "dirs":   {} }
-        reviewer = newpr.choose_reviewer('rust',
-                                         'rust-lang',
-                                         normal_diff,
-                                         'nikomatsakis',
-                                         fake_config)
-        self.assertNotEqual('nikomatsakis', reviewer)
+    def test_choose_reviewer_unsupported_repo(self):
+        """The choose_reviewer function has an escape hatch for calls that
+        are not in specific GitHub organizations or owners. This tests
+        that logic.
+        """
+        diff = self.diff['normal']
+        config = self.config['individuals_no_dirs']
+        test_return = ('test_user_selection_ignore_this', None)
+
+        self.assertNotEqual(
+            test_return,
+            newpr.choose_reviewer(
+                'whatever', 'rust-lang', diff, 'foo', deepcopy(config)
+            )
+        )
+        self.assertNotEqual(
+            test_return,
+            newpr.choose_reviewer(
+                'whatever', 'rust-lang-nursery', diff, 'foo', deepcopy(config)
+            )
+        )
+        self.assertNotEqual(
+            test_return,
+            newpr.choose_reviewer(
+                'whatever', 'rust-lang-deprecated', diff, 'foo',
+                deepcopy(config)
+            )
+        )
+        self.assertNotEqual(
+            test_return,
+            newpr.choose_reviewer(
+                'highfive', 'nrc', diff, 'foo', deepcopy(config)
+            )
+        )
+        self.assertEqual(
+            test_return,
+            newpr.choose_reviewer(
+                'anything', 'else', diff, 'foo', deepcopy(config)
+            )
+        )
+
+    def choose_reviewers(self, diff, config, author):
+        """Helper function that repeatedly calls choose_reviewer to build sets
+        of reviewers and mentions for a given diff, configuration, and
+        author.
+        """
+        chosen_reviewers = set()
+        mentions = set()
+        for _ in xrange(40):
+            reviewer = newpr.choose_reviewer(
+                'rust', 'rust-lang', diff, author, deepcopy(config)
+            )
+            chosen_reviewers.add(reviewer[0])
+            mentions.add(tuple(reviewer[1]))
+        return chosen_reviewers, mentions
+
+    def test_choose_reviewer_individuals_no_dirs_1(self):
+        """Test choosing a reviewer from a list of individual reviewers, no
+        directories, and an author who is not a potential reviewer.
+        """
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.diff['normal'], self.config['individuals_no_dirs'],
+            "nikomatsakis"
+        )
+        self.assertEqual(set(["pnkfelix", "nrc"]), chosen_reviewers)
+        self.assertEqual(set([()]), mentions)
+
+    def test_choose_reviewer_individuals_no_dirs_2(self):
+        """Test choosing a reviewer from a list of individual reviewers, no
+        directories, and an author who is a potential reviewer.
+        """
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.diff['normal'], self.config['individuals_no_dirs'], "nrc"
+        )
+        self.assertEqual(set(["pnkfelix"]), chosen_reviewers)
+        self.assertEqual(set([()]), mentions)


### PR DESCRIPTION
This commit adds a few more tests for the `chooose_reviewer` function. These tests are not comprehensive, but I wanted to get a patch in to indicate I'm working on this. Assuming this is fine with everyone, I'd like to continue doing this.

There's some refactoring in highfive that I'd like to do, as long as that's all right, but given its importance to the Rust project I don't feel comfortable doing that without more testing set up first.