### PR TITLE
Adding more unit tests for `choose_reviewer`

### DIFF
--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -25,6 +25,14 @@ class TestChooseReviewer(TestNewPR):
                 "groups": { "all": ["@pnkfelix", "@nrc"] },
                 "dirs": {},
             },
+            'individuals_dirs' :{
+                "groups": { "all": ["@pnkfelix", "@nrc"] },
+                "dirs": { "librustc": ["@aturon"] },
+            },
+            'individuals_dirs_2' :{
+                "groups": { "all": ["@pnkfelix", "@nrc"] },
+                "dirs": { "foobazdir": ["@aturon"] },
+            },
             'empty' :{
                 "groups": { "all": [] },
                 "dirs": {},
@@ -151,3 +159,25 @@ class TestChooseReviewer(TestNewPR):
         )
         self.assertEqual(set([None]), chosen_reviewers)
         self.assertEqual(set([None]), mentions)
+
+    def test_choose_reviewer_with_dirs(self):
+        """Test choosing a reviewer when directory reviewers are defined that
+        intersect with the diff.
+        """
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.diff['normal'], self.config['individuals_dirs'],
+            "nikomatsakis"
+        )
+        self.assertEqual(set(["pnkfelix", "nrc", "aturon"]), chosen_reviewers)
+        self.assertEqual(set([()]), mentions)
+
+    def test_choose_reviewer_with_dirs_no_intersection(self):
+        """Test choosing a reviewer when directory reviewers are defined that
+        do not intersect with the diff.
+        """
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.diff['normal'], self.config['individuals_dirs_2'],
+            "nikomatsakis"
+        )
+        self.assertEqual(set(["pnkfelix", "nrc"]), chosen_reviewers)
+        self.assertEqual(set([()]), mentions)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -94,14 +94,14 @@ class TestChooseReviewer(TestNewPR):
         author.
         """
         chosen_reviewers = set()
-        mentions = set()
+        mention_list = set()
         for _ in xrange(40):
-            reviewer = self.choose_reviewer(
+            (reviewer, mentions) = self.choose_reviewer(
                 'rust', 'rust-lang', diff, author, deepcopy(config), global_
             )
-            chosen_reviewers.add(reviewer[0])
-            mentions.add(tuple(reviewer[1]))
-        return chosen_reviewers, mentions
+            chosen_reviewers.add(reviewer)
+            mention_list.add(None if mentions is None else tuple(mentions))
+        return chosen_reviewers, mention_list
 
     def test_choose_reviewer_individuals_no_dirs_1(self):
         """Test choosing a reviewer from a list of individual reviewers, no
@@ -139,3 +139,18 @@ class TestChooseReviewer(TestNewPR):
         )
         self.assertEqual(set(['alexcrichton']), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
+
+    def test_choose_reviewer_no_potential(self):
+        """Test choosing a reviewer when nobody qualifies.
+        """
+        global_ = {
+            "groups": {
+                "core": ["@alexcrichton"],
+            }
+        }
+
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.diff['normal'], self.config['empty'], 'alexcrichton', global_
+        )
+        self.assertEqual(set([None]), chosen_reviewers)
+        self.assertEqual(set([None]), mentions)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from highfive import newpr
 from highfive.tests import base
+import mock
 
 class TestNewPR(base.BaseTest):
     pass
@@ -26,6 +27,14 @@ class TestChooseReviewer(TestNewPR):
             }
         }
 
+    @mock.patch('highfive.newpr._load_json_file')
+    def choose_reviewer(
+        self, repo, owner, diff, exclude, config, mock_load_json
+    ):
+        return newpr.choose_reviewer(
+            repo, owner, diff, exclude, deepcopy(config)
+        )
+
     def test_choose_reviewer_unsupported_repo(self):
         """The choose_reviewer function has an escape hatch for calls that
         are not in specific GitHub organizations or owners. This tests
@@ -37,32 +46,32 @@ class TestChooseReviewer(TestNewPR):
 
         self.assertNotEqual(
             test_return,
-            newpr.choose_reviewer(
+            self.choose_reviewer(
                 'whatever', 'rust-lang', diff, 'foo', deepcopy(config)
             )
         )
         self.assertNotEqual(
             test_return,
-            newpr.choose_reviewer(
+            self.choose_reviewer(
                 'whatever', 'rust-lang-nursery', diff, 'foo', deepcopy(config)
             )
         )
         self.assertNotEqual(
             test_return,
-            newpr.choose_reviewer(
+            self.choose_reviewer(
                 'whatever', 'rust-lang-deprecated', diff, 'foo',
                 deepcopy(config)
             )
         )
         self.assertNotEqual(
             test_return,
-            newpr.choose_reviewer(
+            self.choose_reviewer(
                 'highfive', 'nrc', diff, 'foo', deepcopy(config)
             )
         )
         self.assertEqual(
             test_return,
-            newpr.choose_reviewer(
+            self.choose_reviewer(
                 'anything', 'else', diff, 'foo', deepcopy(config)
             )
         )
@@ -75,7 +84,7 @@ class TestChooseReviewer(TestNewPR):
         chosen_reviewers = set()
         mentions = set()
         for _ in xrange(40):
-            reviewer = newpr.choose_reviewer(
+            reviewer = self.choose_reviewer(
                 'rust', 'rust-lang', diff, author, deepcopy(config)
             )
             chosen_reviewers.add(reviewer[0])

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -30,6 +30,13 @@ class TestChooseReviewer(TestNewPR):
                 "dirs": {},
             },
         }
+        cls.global_ = {
+            'base': {
+                "groups": {
+                    "core": ["@alexcrichton"],
+                }
+            }
+        }
 
     def choose_reviewer(
         self, repo, owner, diff, exclude, config, global_ = None
@@ -128,14 +135,9 @@ class TestChooseReviewer(TestNewPR):
         """Test choosing a reviewer from the core group in the global
         configuration.
         """
-        global_ = {
-            "groups": {
-                "core": ["@alexcrichton"],
-            }
-        }
-
         (chosen_reviewers, mentions) = self.choose_reviewers(
-            self.diff['normal'], self.config['empty'], 'fooauthor', global_
+            self.diff['normal'], self.config['empty'], 'fooauthor',
+            self.global_['base']
         )
         self.assertEqual(set(['alexcrichton']), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
@@ -143,14 +145,9 @@ class TestChooseReviewer(TestNewPR):
     def test_choose_reviewer_no_potential(self):
         """Test choosing a reviewer when nobody qualifies.
         """
-        global_ = {
-            "groups": {
-                "core": ["@alexcrichton"],
-            }
-        }
-
         (chosen_reviewers, mentions) = self.choose_reviewers(
-            self.diff['normal'], self.config['empty'], 'alexcrichton', global_
+            self.diff['normal'], self.config['empty'], 'alexcrichton',
+            self.global_['base']
         )
         self.assertEqual(set([None]), chosen_reviewers)
         self.assertEqual(set([None]), mentions)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -62,7 +62,7 @@ class TestChooseReviewer(TestNewPR):
             repo, owner, diff, exclude, deepcopy(config)
         )
 
-    def test_choose_reviewer_unsupported_repo(self):
+    def test_unsupported_repo(self):
         """The choose_reviewer function has an escape hatch for calls that
         are not in specific GitHub organizations or owners. This tests
         that logic.
@@ -118,7 +118,7 @@ class TestChooseReviewer(TestNewPR):
             mention_list.add(None if mentions is None else tuple(mentions))
         return chosen_reviewers, mention_list
 
-    def test_choose_reviewer_individuals_no_dirs_1(self):
+    def test_individuals_no_dirs_1(self):
         """Test choosing a reviewer from a list of individual reviewers, no
         directories, and an author who is not a potential reviewer.
         """
@@ -129,7 +129,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set(["pnkfelix", "nrc"]), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
 
-    def test_choose_reviewer_individuals_no_dirs_2(self):
+    def test_individuals_no_dirs_2(self):
         """Test choosing a reviewer from a list of individual reviewers, no
         directories, and an author who is a potential reviewer.
         """
@@ -139,7 +139,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set(["pnkfelix"]), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
 
-    def test_choose_reviewer_global_core(self):
+    def test_global_core(self):
         """Test choosing a reviewer from the core group in the global
         configuration.
         """
@@ -150,7 +150,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set(['alexcrichton']), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
 
-    def test_choose_reviewer_no_potential(self):
+    def test_no_potential_reviewers(self):
         """Test choosing a reviewer when nobody qualifies.
         """
         (chosen_reviewers, mentions) = self.choose_reviewers(
@@ -160,7 +160,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set([None]), chosen_reviewers)
         self.assertEqual(set([None]), mentions)
 
-    def test_choose_reviewer_with_dirs(self):
+    def test_with_dirs(self):
         """Test choosing a reviewer when directory reviewers are defined that
         intersect with the diff.
         """
@@ -171,7 +171,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set(["pnkfelix", "nrc", "aturon"]), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
 
-    def test_choose_reviewer_with_dirs_no_intersection(self):
+    def test_with_dirs_no_intersection(self):
         """Test choosing a reviewer when directory reviewers are defined that
         do not intersect with the diff.
         """


### PR DESCRIPTION
This PR tests `choose_reviewer` for cases with global configs and directory configurations. It also refactors the tests, as needed, and mocks out the loading of the global configuration to make it controllable in the test.

This is a continuation of #93.