### PR TITLE
Adding tests for `find_reviewer` and minor editing

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -199,8 +199,8 @@ def is_new_contributor(username, owner, repo, user, token, config):
         url = links['next']
 
 # If the user specified a reviewer, return the username, otherwise returns None.
-def find_reviewer(commit_msg):
-    match = reviewer_re.search(commit_msg)
+def find_reviewer(msg):
+    match = reviewer_re.search(msg)
     return match.group(1) if match else None
 
 # Choose a reviewer for the PR

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -201,9 +201,7 @@ def is_new_contributor(username, owner, repo, user, token, config):
 # If the user specified a reviewer, return the username, otherwise returns None.
 def find_reviewer(commit_msg):
     match = reviewer_re.search(commit_msg)
-    if not match:
-        return None
-    return match.group(1)
+    return match.group(1) if match else None
 
 # Choose a reviewer for the PR
 def choose_reviewer(repo, owner, diff, exclude, config):


### PR DESCRIPTION
This PR adds tests for `find_reviewer` and makes small changes to the function.

---

While I have your attention, I'd like to reveal a glimpse into my plan, in case you want to suggest otherwise. My next step here is going to be to change the regular expression to only match valid GitHub user names (e.g., "D--a--s-h" is not valid) and also make the following cases that currently extract a username return `None`:
- `'....@!##$@#%r? @foo'` (make the [r|R] be the beginning of the line or preceded by whitespace)
- `'r?:-:-:- @foo'` (allow only zero or one [:|-] character following the "?")

Since I'm in the area, I'll probably also look into whether #39 makes sense to do right around now.