### PR TITLE
Testing `_load_json_file` and a small change

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -73,7 +73,7 @@ def _load_json_file(name):
     configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
 
     with open(os.path.join(configs_dir, name)) as config:
-        return json.loads(config.read())
+        return json.load(config)
 
 def api_req(method, url, data=None, username=None, token=None, media_type=None):
     data = None if not data else json.dumps(data)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -1,12 +1,23 @@
 from copy import deepcopy
 from highfive import newpr
 from highfive.tests import base
+import json
 import mock
 
 class TestNewPR(base.BaseTest):
     pass
 
 class TestNewPRGeneral(TestNewPR):
+    @mock.patch('os.path.dirname')
+    def test_load_json_file(self, mock_dirname):
+        mock_dirname.return_value = '/the/path'
+        contents = ['some json']
+        with mock.patch(
+            '__builtin__.open', mock.mock_open(read_data=json.dumps(contents))
+        ) as mock_file:
+            self.assertEqual(newpr._load_json_file('a-config.json'), contents)
+            mock_file.assert_called_with('/the/path/configs/a-config.json')
+
     def test_submodule(self):
         submodule_diff = self._load_fake('submodule.diff')
         self.assertTrue(newpr.modifies_submodule(submodule_diff))


### PR DESCRIPTION
This PR adds a test for `_load_json_file` and changes its JSON loading call to use the file object instead of reading the file to string first.