### PR TITLE
Modifying the reviewer regex to more closely match GitHub usernames

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -62,7 +62,26 @@ def review_msg(reviewer, submitter):
         text = review_with_reviewer % reviewer
     return text
 
-reviewer_re = re.compile("\\b[rR]\?[:\- ]*@([a-zA-Z0-9\-]+)")
+# This regular expression has a lot going on. Here are explanations to go along
+# with the numbers below.
+#
+# 1. The expression is either at the beginning of a string or is preceded by
+#    whitespace.
+# 2. The target string begins with 'r' or 'R' followed by a '?'.
+# 3. The '?' is followed by up to one ':' or '-'.
+# 4. At least one whitespace character separates the first pattern from the
+#    username pattern.
+# 5. The username is preceded by an '@' character.
+# 6. The username begins with a letter or digit.
+# 7. The username continues with up to thirty-eight letters or digits or single
+#    instances of '-' characters.
+# 8. The end of the username is either the end of the string or is followed by
+#    a character that is not a letter or digit or '-' character.
+reviewer_re = re.compile(
+    # |   1   |  2   | 3  | 4|5|    6     |                  7                   |         8         |
+    r"(?:^|\s+)[rR]\?[:\-]?\s+@([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})(?:$|[^a-zA-Z0-9\-])"
+)
+
 unsafe_re = re.compile("\\bunsafe\\b|#!?\\[unsafe_")
 submodule_re = re.compile(".*\+Subproject\scommit\s.*", re.DOTALL|re.MULTILINE)
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -18,19 +18,35 @@ class TestNewPRGeneral(TestNewPR):
         found_cases = (
             ('r? @foo', 'foo'),
             ('R? @foo', 'foo'),
-            ('....@!##$@#%r? @foo', 'foo'),
-            ('r?:-:-:- @foo', 'foo'),
-            ('Lorem ipsum dolor sit amet, r?@foo consectetur', 'foo'),
+            ('r?: @foo', 'foo'),
+            ('r?- @foo', 'foo'),
+            ('Lorem ipsum dolor sit amet, r? @foo consectetur', 'foo'),
             ('r? @8iAke', '8iAke'),
-            ('r? @D--a--s-h', 'D--a--s-h'),
+            ('r? @D-a-s-h', 'D-a-s-h'),
             ('r? @foo$', 'foo'),
+            (
+                'r? @012345678901234567890123456789012345678',
+                '012345678901234567890123456789012345678'
+            ),
+            (
+                'r? @0-2-4-6-8-0-2-4-6-8-0-2-4-6-8-0-2-4-6-8',
+                '0-2-4-6-8-0-2-4-6-8-0-2-4-6-8-0-2-4-6-8'
+            ),
         )
         not_found_cases = (
             'rr? @foo',
             'r @foo',
             'r?! @foo',
+            'r?@foo',
             'r? foo',
             'r? @',
+            '....@r? @foo',
+            'r?:- @foo',
+            'r? @D--a', # consecutive dashes are forbidden
+            'r? @-foo', # usernames cannot begin with a dash
+            'r? @foo-', # usernames cannot end with a dash
+            'r? @0123456789012345678901234567890123456789', # too long
+            'r? @0-2-4-6-8-0-2-4-6-8-0-2-4-6-8-0-2-4-6-89', # also too long
         )
 
         for (msg, reviewer) in found_cases:


### PR DESCRIPTION
GitHub usernames contain only alphanumeric characters or single hyphens, do not start or finish with hyphens, and are at most thirty-nine characters long. This can be discerned looking at the [join page](https://github.com/join).

![image](https://user-images.githubusercontent.com/933552/36640141-7e914d9e-19ce-11e8-9a03-f60a7db43330.png)
![image](https://user-images.githubusercontent.com/933552/36640126-62487b94-19ce-11e8-97ac-fbba526b3fa2.png)

This PR adapts the regular expression used in `find_reviewer` to match on these constraints. I used the regular expression [here](https://github.com/shinnn/github-username-regex/blob/master/module.js) and adapted it to the needs of the expression in this project.

This is related to #96 and does not include changes for #39. That will come later.