### PR TITLE
Updating shebang to use first interpreter on the PATH

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import base64
 import urllib, urllib2


### PR DESCRIPTION
The current shebang doesn't play nice with virtual environments. I started running a highfive instance locally, and this was one of the issues I encountered. It's somewhat minor since highfive doesn't have any non-test dependencies, but in my case /usr/bin/python is a different version that I had going in my virtual environment, which ended up being an issue.