### PR TITLE
Adding `unexpected_match` tests

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -323,22 +323,17 @@ def modifies_submodule(diff):
     return submodule_re.match(diff)
 
 def unexpected_branch(payload, config):
-    """ returns (expected_branch, actual_branch) if they differ, else None
+    """ returns (expected_branch, actual_branch) if they differ, else False
     """
 
     # If unspecified, assume master.
-    expected_target = None
-    if "expected_branch" in config:
-        expected_target = config["expected_branch"]
-    if not expected_target:
-        expected_target = "master"
+    expected_target = config.get('expected_branch', 'master')
 
     # ie we want "stable" in this: "base": { "label": "rust-lang:stable"...
     actual_target = payload['pull_request']['base']['label'].split(':')[1]
 
-    if expected_target != actual_target:
-        return (expected_target, actual_target)
-    return False
+    return (expected_target, actual_target) \
+        if expected_target != actual_target else False
 
 def get_irc_nick(gh_name):
     """ returns None if the request status code is not 200,

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -25,6 +25,32 @@ class TestNewPRGeneral(TestNewPR):
         normal_diff = self._load_fake('normal.diff')
         self.assertFalse(newpr.modifies_submodule(normal_diff))
 
+    def test_expected_branch_default_expected_no_match(self):
+        payload = {'pull_request': {'base': {'label': 'repo-owner:dev'}}}
+        config = {}
+        self.assertEqual(
+            newpr.unexpected_branch(payload, config),
+            ('master', 'dev')
+        )
+
+    def test_expected_branch_default_expected_match(self):
+        payload = {'pull_request': {'base': {'label': 'repo-owner:master'}}}
+        config = {}
+        self.assertFalse(newpr.unexpected_branch(payload, config))
+
+    def test_expected_branch_custom_expected_no_match(self):
+        payload = {'pull_request': {'base': {'label': 'repo-owner:master'}}}
+        config = {'expected_branch': 'dev' }
+        self.assertEqual(
+            newpr.unexpected_branch(payload, config),
+            ('dev', 'master')
+        )
+
+    def test_expected_branch_custom_expected_match(self):
+        payload = {'pull_request': {'base': {'label':'repo-owner:dev'}}}
+        config = {'expected_branch': 'dev' }
+        self.assertFalse(newpr.unexpected_branch(payload, config))
+
     def test_find_reviewer(self):
         found_cases = (
             ('r? @foo', 'foo'),


### PR DESCRIPTION
This PR contains two parts:
- Adding tests for `unexpected_match`. These passed before the next step.
- Modifying the logic of `unexpected_match` to be more concise.