### PR TITLE
Fixing error in submodule PR handling

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -387,7 +387,7 @@ def new_pr(payload, user, token):
         warnings.append(surprise_branch_warning % surprise)
 
     if modifies_submodule(diff):
-        warnings.append(submodule_warning_msgs)
+        warnings.append(submodule_warning_msg)
 
     if warnings:
         post_comment(warning_summary % '\n'.join(map(lambda x: '* ' + x, warnings)), owner, repo, issue, user, token)


### PR DESCRIPTION
This PR fixes what must be an exception-causing issue in the project. It looks like highfive must be failing when a PR is modifying a submodule due to the use of an undefined variable (it's a typo). This PR corrects that.

In order to review this, you'll want to look through the [full file](https://github.com/rust-lang-nursery/highfive/blob/939b9091334150d085c8591f2e60e816024b8062/highfive/newpr.py) for instances of "submodule_warning_msg". Note that "submodule_warning_msgs" does not exist.

I haven't added a test or otherwise tested this yet. I'm planning to reorganize the call to `modifies_submodule` in the next PR and add tests for that. Otherwise, I would test it now, but since it seems pretty clear to me that it can't be working I feel comfortable making the change straight up for now.