### PR TITLE
Removing duplicate-name partial test class

### DIFF
--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -87,13 +87,6 @@ class TestNewPRGeneral(TestNewPR):
             )
 
 class TestNewComment(TestNewPR):
-    mock_args = {
-        'get_collaborators': mock.DEFAULT,
-        'find_reviewer': mock.DEFAULT,
-        'set_assignee': mock.DEFAULT,
-    }
-
-class TestNewComment(TestNewPR):
     def setUp(self):
         super(TestNewComment, self).setUp()
 


### PR DESCRIPTION
I accidentally created a second instance of `TestNewComment ` in #103. This PR removes the definition of `TestNewComment` that is not doing anything.