### PR TITLE
User is collaborator check

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -22,7 +22,6 @@ from highfive import irc
 contributors_url = "https://api.github.com/repos/%s/%s/contributors?per_page=100"
 post_comment_url = "https://api.github.com/repos/%s/%s/issues/%s/comments"
 user_collabo_url = "https://api.github.com/repos/%s/%s/collaborators/%s"
-collabo_url = "https://api.github.com/repos/%s/%s/collaborators"
 issue_url = "https://api.github.com/repos/%s/%s/issues/%s"
 issue_labels_url = "https://api.github.com/repos/%s/%s/issues/%s/labels"
 
@@ -134,17 +133,6 @@ def is_collaborator(commenter, owner, repo, user, token):
         return True
     except urllib2.HTTPError:
         return False
-
-def get_collaborators(owner, repo, user, token):
-    try:
-        result = api_req("GET", collabo_url % (owner, repo), None, user, token)['body']
-    except urllib2.HTTPError, e:
-        if e.code == 201:
-            pass
-        else:
-            raise e
-    return [c['login'] for c in json.loads(result)]
-
 
 def add_labels(labels, owner, repo, issue, user, token):
     try:
@@ -419,8 +407,8 @@ def new_comment(payload, user, token):
     # Check the commenter is the submitter of the PR or the previous assignee.
     author = payload["issue"]['user']['login']
     if not (author == commenter or (payload['issue']['assignee'] and commenter == payload['issue']['assignee']['login'])):
-        # Get collaborators for this repo and check if the commenter is one of them
-        if commenter not in get_collaborators(owner, repo, user, token):
+        # Check if commenter is a collaborator.
+        if not is_collaborator(commenter, owner, repo, user, token):
             return
 
     # Check for r? and set the assignee.

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -21,6 +21,7 @@ from highfive import irc
 # contributor will happen early,
 contributors_url = "https://api.github.com/repos/%s/%s/contributors?per_page=100"
 post_comment_url = "https://api.github.com/repos/%s/%s/issues/%s/comments"
+user_collabo_url = "https://api.github.com/repos/%s/%s/collaborators/%s"
 collabo_url = "https://api.github.com/repos/%s/%s/collaborators"
 issue_url = "https://api.github.com/repos/%s/%s/issues/%s"
 issue_labels_url = "https://api.github.com/repos/%s/%s/issues/%s/labels"
@@ -126,6 +127,13 @@ def set_assignee(assignee, owner, repo, issue, user, token, author, to_mention):
                                         ','.join([x for x in mention['reviewers'] if x != user]))
         post_comment(message, owner, repo, issue, user, token)
 
+def is_collaborator(commenter, owner, repo, user, token):
+    """Returns True if `commenter` is a collaborator in the repo."""
+    try:
+        api_req("GET", user_collabo_url % (owner, repo, commenter), None, user, token)
+        return True
+    except urllib2.HTTPError:
+        return False
 
 def get_collaborators(owner, repo, user, token):
     try:

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -131,8 +131,11 @@ def is_collaborator(commenter, owner, repo, user, token):
     try:
         api_req("GET", user_collabo_url % (owner, repo, commenter), None, user, token)
         return True
-    except urllib2.HTTPError:
-        return False
+    except urllib2.HTTPError, e:
+        if e.code == 404:
+            return False
+        else:
+            raise e
 
 def add_labels(labels, owner, repo, issue, user, token):
     try:

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -151,6 +151,19 @@ Please see [the contribution instructions](%s) for more information.
             None, 'integrationUser', 'credential'
         )
 
+    @mock.patch('highfive.newpr.api_req')
+    def test_is_collaborator_error(self, mock_api_req):
+        mock_api_req.side_effect = HTTPError(None, 500, None, None, None)
+        self.assertRaises(
+            HTTPError, newpr.is_collaborator, 'commentUser', 'repo-owner',
+            'repo-name', 'integrationUser', 'credential'
+        )
+        mock_api_req.assert_called_with(
+            'GET',
+            'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
+            None, 'integrationUser', 'credential'
+        )
+
     def test_submodule(self):
         submodule_diff = self._load_fake('submodule.diff')
         self.assertTrue(newpr.modifies_submodule(submodule_diff))

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -122,6 +122,35 @@ Please see [the contribution instructions](%s) for more information.
             {'body': 'Request body!'}, 'integrationUser', 'credential'
         )
 
+    @mock.patch('highfive.newpr.api_req')
+    def test_is_collaborator_true(self, mock_api_req):
+        self.assertTrue(
+            newpr.is_collaborator(
+                'commentUser', 'repo-owner', 'repo-name', 'integrationUser',
+                'credential'
+            )
+        )
+        mock_api_req.assert_called_with(
+            'GET',
+            'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
+            None, 'integrationUser', 'credential'
+        )
+
+    @mock.patch('highfive.newpr.api_req')
+    def test_is_collaborator_false(self, mock_api_req):
+        mock_api_req.side_effect = HTTPError(None, 404, None, None, None)
+        self.assertFalse(
+            newpr.is_collaborator(
+                'commentUser', 'repo-owner', 'repo-name', 'integrationUser',
+                'credential'
+            )
+        )
+        mock_api_req.assert_called_with(
+            'GET',
+            'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
+            None, 'integrationUser', 'credential'
+        )
+
     def test_submodule(self):
         submodule_diff = self._load_fake('submodule.diff')
         self.assertTrue(newpr.modifies_submodule(submodule_diff))


### PR DESCRIPTION
GitHub (now) has an endpoint to [check if a user is a collaborator](https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator). Currently, Highfive uses the [list collaborators endpoint](https://developer.github.com/v3/repos/collaborators/#list-collaborators) and then checks the response to see if the expected user is there. I assume this response is subject to being paginated in projects with lots of collaborators. Highfive, however, isn't handling pagination in this case. I don't know if that's an issue (i.e., I don't know how many contributors rust-lang/rust has; a problem would manifest as Highfive ignoring "r? @" comments from some collaborators), but it seems like an issue waiting to happen.

This PR modifies Highfive to check if a specific user is a reviewer.

In addition to the unit tests, I manually verified that `is_collaborator` is working as expected. Here's the log of that:
```python
>>> from newpr import is_collaborator
>>> is_collaborator('blah', 'davidalber', 'highfive-test-repo', 'davidalber', OAUTH_TOKEN)
False

>>> is_collaborator('davidalber', 'davidalber', 'highfive-test-repo', 'davidalber', OAUTH_TOKEN)
True

>>> is_collaborator('nrc', 'davidalber', 'highfive-test-repo', 'davidalber', OAUTH_TOKEN)
False
```

~Here is some justification for caution: I haven't tested this on a Highfive instance running against a repository. (I'm working on this now, but I keep accidentally opening my PR here. Rather than closing this again and making more noise, I am just going to update this comment when I'm done.)~