### PR TITLE
Modifying and testing `add_labels`

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -138,13 +138,7 @@ def is_collaborator(commenter, owner, repo, user, token):
             raise e
 
 def add_labels(labels, owner, repo, issue, user, token):
-    try:
-        result = api_req("POST", issue_labels_url % (owner, repo, issue), labels, user, token)
-    except urllib2.HTTPError, e:
-        if e.code == 201:
-            pass
-        else:
-            raise e
+    api_req("POST", issue_labels_url % (owner, repo, issue), labels, user, token)
 
 
 # This function is adapted from https://github.com/kennethreitz/requests/blob/209a871b638f85e2c61966f82e547377ed4260d9/requests/utils.py#L562

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -180,22 +180,6 @@ Please see [the contribution instructions](%s) for more information.
         )
 
     @mock.patch('highfive.newpr.api_req')
-    def test_add_labels_error_201(self, mock_api_req):
-        mock_api_req.return_value = {}
-        mock_api_req.side_effect = HTTPError(None, 201, None, None, None)
-        labels = ['label1', 'label2']
-        self.assertIsNone(
-            newpr.add_labels(
-                labels, 'repo-owner', 'repo-name', 7, 'integrationUser',
-                'credential'
-            )
-        )
-        mock_api_req.assert_called_with(
-            'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
-            labels, 'integrationUser', 'credential'
-        )
-
-    @mock.patch('highfive.newpr.api_req')
     def test_add_labels_error(self, mock_api_req):
         mock_api_req.return_value = {}
         mock_api_req.side_effect = HTTPError(None, 422, None, None, None)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -164,6 +164,51 @@ Please see [the contribution instructions](%s) for more information.
             None, 'integrationUser', 'credential'
         )
 
+    @mock.patch('highfive.newpr.api_req')
+    def test_add_labels_success(self, mock_api_req):
+        mock_api_req.return_value = {'body': 'response body!'}
+        labels = ['label1', 'label2']
+        self.assertIsNone(
+            newpr.add_labels(
+                labels, 'repo-owner', 'repo-name', 7, 'integrationUser',
+                'credential'
+            )
+        )
+        mock_api_req.assert_called_with(
+            'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
+            labels, 'integrationUser', 'credential'
+        )
+
+    @mock.patch('highfive.newpr.api_req')
+    def test_add_labels_error_201(self, mock_api_req):
+        mock_api_req.return_value = {}
+        mock_api_req.side_effect = HTTPError(None, 201, None, None, None)
+        labels = ['label1', 'label2']
+        self.assertIsNone(
+            newpr.add_labels(
+                labels, 'repo-owner', 'repo-name', 7, 'integrationUser',
+                'credential'
+            )
+        )
+        mock_api_req.assert_called_with(
+            'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
+            labels, 'integrationUser', 'credential'
+        )
+
+    @mock.patch('highfive.newpr.api_req')
+    def test_add_labels_error(self, mock_api_req):
+        mock_api_req.return_value = {}
+        mock_api_req.side_effect = HTTPError(None, 422, None, None, None)
+        labels = ['label1', 'label2']
+        self.assertRaises(
+            HTTPError, newpr.add_labels, labels, 'repo-owner', 'repo-name',
+            7, 'integrationUser', 'credential'
+        )
+        mock_api_req.assert_called_with(
+            'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
+            labels, 'integrationUser', 'credential'
+        )
+
     def test_submodule(self):
         submodule_diff = self._load_fake('submodule.diff')
         self.assertTrue(newpr.modifies_submodule(submodule_diff))


### PR DESCRIPTION
This PR does two things:
- Removes the try-except logic from `add_labels`. I'm doing this because the [add labels request](https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue) returns 200 on success. Thus, we don't need the "look for 201 status code logic" here.
- Adds tests for `add_labels`.

I also verified the modified function manually.
```python
>>> from newpr import add_labels
>>> add_labels(['a', 'b'], 'davidalber', 'highfive-test-repo', 2, 'davidalber', OAUTH_TOKEN)

>>> add_labels(['a', 'b'], 'davidalber', 'highfive-test-repo', 2, 'davidalber', FAKE_OAUTH_TOKEN)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "newpr.py", line 143, in add_labels
    api_req("POST", issue_labels_url % (owner, repo, issue), labels, user, token)
  File "newpr.py", line 86, in api_req
    f = urllib2.urlopen(req)
  File "/usr/local/Cellar/python/2.7.14/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ur
llib2.py", line 154, in urlopen
.
.
.
urllib2.HTTPError: HTTP Error 401: Unauthorized
```

_This is probably going to conflict with #111, after it is merged, so I'll need to rebase one of them._