### PR TITLE
Adding an explanation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Highfive [![Build Status](https://travis-ci.org/rust-lang-nursery/highfive.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/highfive)
 ========
 
-GitHub hooks to provide an encouraging atmosphere for new contributors
+GitHub hooks to provide an encouraging atmosphere for new
+contributors. Highfive assigns pull requests to users based on rules
+in configuration files. You can see Highfive in action in several Rust
+repositories. See the [rust-lang/rust pull
+requests](https://github.com/rust-lang/rust/pulls), for example.
 
 Install
 =======


### PR DESCRIPTION
This PR adds a couple sentences to the README to explain what Highfive does. You can see the rendered version of these changes in the first paragraph [here](https://github.com/davidalber/highfive/tree/3e7c79c5f2d12fcb638014c34757a3524cf39ded).

Fixes #63.