### PR TITLE
Updating OAuth authorization mechanism

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import base64
 import urllib, urllib2
 import cgi
 import cgitb
@@ -78,8 +77,7 @@ def api_req(method, url, data=None, username=None, token=None, media_type=None):
     req = urllib2.Request(url, data, headers)
     req.get_method = lambda: method
     if token:
-        base64string = base64.standard_b64encode('%s:x-oauth-basic' % (token)).replace('\n', '')
-        req.add_header("Authorization", "Basic %s" % base64string)
+        req.add_header("Authorization", "token %s" % token)
 
     if media_type:
         req.add_header("Accept", media_type)


### PR DESCRIPTION
The authorization header Highfive currently uses is similar, but does not match the GitHub API documentation on authorization. I'm guessing the approach being used has been deprecated. This PR updates the authorization to implement the [OAuth 2 token (sent in a header)](https://developer.github.com/v3/#oauth2-token-sent-in-a-header) approach.

The correctness of this change isn't covered by the tests, so I tested manually. Here's what happened when I deliberately make the authorization header incorrect (expected to fail):
```python
>>> import newpr
>>> newpr.is_collaborator('TapscottLab', 'davidalber', 'highfive-test-repo', 'davidalber', OAUTH_TOKEN)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "newpr.py", line 136, in is_collaborator
    raise e
urllib2.HTTPError: HTTP Error 401: Unauthorized
```

Here's what happened when I did the same thing with the changes in this PR in place:
```python
>>> import newpr
>>> newpr.is_collaborator('TapscottLab', 'davidalber', 'highfive-test-repo', 'davidalber', OAUTH_TOKEN)
True
```