### PR TITLE
Adding tests for `set_assignee`

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -99,7 +99,6 @@ def post_comment(body, owner, repo, issue, user, token):
             raise e
 
 def set_assignee(assignee, owner, repo, issue, user, token, author, to_mention):
-    global issue_url
     try:
         result = api_req("PATCH", issue_url % (owner, repo, issue), {"assignee": assignee}, user, token)['body']
     except urllib2.HTTPError, e:


### PR DESCRIPTION
This PR adds tests for `set_assignee`. It also removes a `global` statement for a global variable not being assigned to.

```
$ nosetests -s --with-coverage --cover-package=highfive --cover-erase --cover-html
.......................................................
Name                   Stmts   Miss  Cover
------------------------------------------
highfive/__init__.py       0      0   100%
highfive/irc.py           33      4    88%
highfive/newpr.py        282     75    73%
------------------------------------------
TOTAL                    315     79    75%
----------------------------------------------------------------------
Ran 55 tests in 0.567s

OK
```