### PR TITLE
Dev hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,41 @@ Leave the 'secret' field blank.
 Let me select individual events: Issue comment, pull request
 Check the box by 'Active'
 
+Local Development
+-----------------
+
+You can run Highfive on your machine and configure a repository to use
+your local instance. Here is one approach for running a local server:
+
+- Use [serve.py](/serve.py) to run the Highfive service. From the
+  repository root, do:
+  ```
+  $ PYTHONPATH=$PYTHONPATH:$PWD python serve.py
+  ```
+  Now you have Highfive listening on port 8000 of your machine.
+- Your Highfive instance will need to be reachable from outside your
+  machine. If that's possible without further work, skip to the next
+  item. Otherwise, something needs to be figured out.
+
+  An easy way to handle this for development is to use
+  [ngrok](https://ngrok.com/). If you go that route, you will get a
+  temporary domain name that proxies to your Highfive
+  instance. Additionally, you will be able to use ngrok's inspector to
+  easily examine and replay the requests.
+- Set up the web hook following the instructions in [Enabling a
+  Repo](#enabling-a-repo), substituting your local Highfive IP address
+  or domain name and port (if necessary).
+
+Here are couple things to watch out for:
+
+- The beginning of `choose_reviewer` in
+  [highfive/newpr.py](/highfive/newpr.py) contains logic that causes
+  Highfive to ignore requests from unqualified repositories. You will
+  likely need to modify this logic in order for your local Highfive to
+  take action on new PRs.
+- For Highfive to know how to select reviewers for your repository,
+  you need a configuration file in
+  [highfive/configs](/highfive/configs).
+
 [rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
 

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,23 @@
+"""A simple CGI HTTP server for Highfive.
+
+This script should be run from the repository root (i.e., the same
+directory this file resides in). Provide the repository root path in
+PYTHONPATH. Example:
+
+    $ PYTHONPATH=$PYTHONPATH:$PWD python serve.py
+"""
+
+import BaseHTTPServer
+import CGIHTTPServer
+import highfive
+
+PORT = 8000
+
+server = BaseHTTPServer.HTTPServer
+handler = CGIHTTPServer.CGIHTTPRequestHandler
+server_address = ('', PORT)
+handler.cgi_directories = ['/highfive']
+
+httpd = server(server_address, handler)
+print "Serving at port", PORT
+httpd.serve_forever()


### PR DESCRIPTION
This PR adds instructions showing a way to run Highfive in the context of doing development. Until I delete the branch, you can see a live version of the README changes [here](https://github.com/davidalber/highfive/tree/dev-hosting-instructions#local-development).