### PR TITLE
Adding integration tests for `is_new_contributor`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,10 @@ install:
   - "pip install -r test-requirements.txt"
 
 # command to run tests
-script: nosetests
+script:
+  - |
+    if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+      nosetests
+    else
+      nosetests -a type=unit
+    fi

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -1,0 +1,31 @@
+from highfive import newpr
+from highfive.tests import base
+from nose.plugins.attrib import attr
+
+@attr(type='integration')
+class TestIsNewContributor(base.BaseTest):
+    def setUp(self):
+        super(TestIsNewContributor, self).setUp()
+
+        self.payload = {'repository': {'fork': False}}        
+
+    def test_real_contributor_true(self):
+        self.assertTrue(
+            newpr.is_new_contributor(
+                'nrc', 'rust-lang', 'rust', '', None, self.payload
+            )
+        )
+
+    def test_real_contributor_false(self):
+        self.assertFalse(
+            newpr.is_new_contributor(
+                'octocat', 'rust-lang', 'rust', '', None, self.payload
+            )
+        )
+
+    def test_fake_user(self):
+        self.assertFalse(
+            newpr.is_new_contributor(
+                'fjkesfgojsrgljsdgla', 'rust-lang', 'rust', '', None, self.payload
+            )
+        )

--- a/highfive/tests/test_irc.py
+++ b/highfive/tests/test_irc.py
@@ -2,7 +2,9 @@ import mock
 
 from highfive import irc
 from highfive.tests import base
+from nose.plugins.attrib import attr
 
+@attr(type='unit')
 class TestIrc(base.BaseTest):
 
     def test_send_and_join(self):

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -3,8 +3,10 @@ from highfive import newpr
 from highfive.tests import base
 import json
 import mock
+from nose.plugins.attrib import attr
 from urllib2 import HTTPError
 
+@attr(type='unit')
 class TestNewPR(base.BaseTest):
     def setUp(self):
         super(TestNewPR, self).setUp()


### PR DESCRIPTION
As promised in #119, this PR adds integration tests for `is_new_contributor`. I've modified the Travis CI config (and added test attributes) to not run these new tests in PR builds. If we have a cron build (preferably daily), the integration tests will run in that. If we don't have one set up, we should turn that on.

This PR should generate a build that runs sixty tests. [Here's a cron build](https://travis-ci.org/davidalber/highfive/builds/359685473) on my fork repository that additionally ran the three tests in this PR.