### PR TITLE
Fixing the currently-inverted logic in `is_new_contributor`

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -178,10 +178,10 @@ def is_new_contributor(username, owner, repo, token, payload):
             'GET', commit_search_url % (owner, repo, username), None, token,
             'application/vnd.github.cloak-preview'
         )
-        return json.loads(result['body'])['total_count'] > 0
+        return json.loads(result['body'])['total_count'] == 0
     except urllib2.HTTPError, e:
         if e.code == 422:
-            return False
+            return True
         else:
             raise e
 

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -10,21 +10,21 @@ class TestIsNewContributor(base.BaseTest):
         self.payload = {'repository': {'fork': False}}        
 
     def test_real_contributor_true(self):
-        self.assertTrue(
+        self.assertFalse(
             newpr.is_new_contributor(
                 'nrc', 'rust-lang', 'rust', '', self.payload
             )
         )
 
     def test_real_contributor_false(self):
-        self.assertFalse(
+        self.assertTrue(
             newpr.is_new_contributor(
                 'octocat', 'rust-lang', 'rust', '', self.payload
             )
         )
 
     def test_fake_user(self):
-        self.assertFalse(
+        self.assertTrue(
             newpr.is_new_contributor(
                 'fjkesfgojsrgljsdgla', 'rust-lang', 'rust', '', self.payload
             )

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -626,17 +626,17 @@ class TestIsNewContributor(TestNewPR):
 
     def test_is_new_contributor_has_commits(self):
         self.mocks['api_req'].return_value = self.api_return(5)
-        self.assertTrue(self.is_new_contributor())
+        self.assertFalse(self.is_new_contributor())
         self.assert_api_req_call()
 
     def test_is_new_contributor_no_commits(self):
         self.mocks['api_req'].return_value = self.api_return(0)
-        self.assertFalse(self.is_new_contributor())
+        self.assertTrue(self.is_new_contributor())
         self.assert_api_req_call()
 
     def test_is_new_contributor_nonexistent_user(self):
         self.mocks['api_req'].side_effect = HTTPError(None, 422, None, None, None)
-        self.assertFalse(self.is_new_contributor())
+        self.assertTrue(self.is_new_contributor())
         self.assert_api_req_call()
 
     def test_is_new_contributor_error(self):


### PR DESCRIPTION
The logic in `is_new_contributor` is currently backwards (i.e., it is returning `True` for existing contributors). You can see Highfive sending the welcome message to an existing contributor in rust-lang/rust#49795, for example.

This PR inverts the logic so that `is_new_contributor` returns `True` for new contributors and `False` for existing contributors.