### PR TITLE
Updating package URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(name='highfive',
       description='GitHub hooks to provide an encouraging atmosphere for new contributors',
       author='Rust Community',
       author_email='no-idea@no-server.no-suffix',
-      url='https://github.com/nick29581/highfive',
+      url='https://github.com/rust-lang-nursery/highfive',
       packages=['highfive'],
 )


### PR DESCRIPTION
This PR updates the package URL. The current URL already redirects to the current repo location. This eliminates the redirection.