### PR TITLE
Use warning emoji instead of external image

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -46,7 +46,7 @@ def welcome_msg(reviewer, config):
         link = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md"
     return raw_welcome % (text, link)
 
-warning_summary = '<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>\n\n%s'
+warning_summary = ':warning: **Warning** :warning:\n\n%s'
 unsafe_warning_msg = 'These commits modify **unsafe code**. Please review it carefully!'
 submodule_warning_msg = 'These commits modify **submodules**.'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -674,7 +674,7 @@ class TestPostWarnings(TestNewPR):
         )
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
-        expected_warning = """<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>
+        expected_warning = """:warning: **Warning** :warning:
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!"""
         self.mocks['post_comment'].assert_called_with(
@@ -692,7 +692,7 @@ class TestPostWarnings(TestNewPR):
         )
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
-        expected_warning = """<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>
+        expected_warning = """:warning: **Warning** :warning:
 
 * These commits modify **submodules**."""
         self.mocks['post_comment'].assert_called_with(
@@ -712,7 +712,7 @@ class TestPostWarnings(TestNewPR):
         )
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
-        expected_warning = """<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>
+        expected_warning = """:warning: **Warning** :warning:
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
 * These commits modify **submodules**."""


### PR DESCRIPTION
Under some conditions (e.g., when submodules are modified, like [here](https://github.com/rust-lang/rust/pull/50893#issuecomment-390413197)) Highfive posts warning messages. The beginning of the warning looks like this:
![image](https://user-images.githubusercontent.com/933552/40274435-7221557e-5b8a-11e8-8c1a-4c374275a2ed.png)

The warning icons in that message are an SVG from an external location ([here](http://www.joshmatthews.net/warning.svg)). At this point, GitHub supports a diverse set of emoji, including a warning icon: ⚠️. This PR replaces the use of the external SVG with the emoji. This will be more future proof and it is generally nicer to use the built-in emoji, as long as you are all right with the color change. Here's how the beginning of the warning looks with the emoji:
![image](https://user-images.githubusercontent.com/933552/40274453-04cd775e-5b8b-11e8-8b74-636d8af7231d.png)
