### PR TITLE
Reorganizing Highfive handler functions into a class

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -65,12 +65,6 @@ submodule_re = re.compile(".*\+Subproject\scommit\s.*", re.DOTALL|re.MULTILINE)
 rustaceans_api_url = "http://www.ncameron.org/rustaceans/user?username={username}"
 
 
-def _load_json_file(name):
-    configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
-
-    with open(os.path.join(configs_dir, name)) as config:
-        return json.load(config)
-
 def api_req(method, url, data=None, token=None, media_type=None):
     data = None if not data else json.dumps(data)
     headers = {} if not data else {'Content-Type': 'application/json'}
@@ -105,7 +99,7 @@ class HighfiveHandler(object):
         if self.payload["action"] == "opened":
             # If this is a new PR, load the repository configuration.
             repo = self.payload['pull_request', 'base', 'repo', 'name']
-            return _load_json_file(repo + '.json')
+            return self._load_json_file(repo + '.json')
 
         return None
 
@@ -117,6 +111,12 @@ class HighfiveHandler(object):
         else:
             print self.payload["action"]
             sys.exit(0)
+
+    def _load_json_file(self, name):
+        configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
+
+        with open(os.path.join(configs_dir, name)) as config:
+            return json.load(config)
 
     def modifies_submodule(self, diff):
         return submodule_re.match(diff)
@@ -259,7 +259,7 @@ class HighfiveHandler(object):
 
         # fill in the default groups, ensuring that overwriting is an
         # error.
-        global_ = _load_json_file('_global.json')
+        global_ = self._load_json_file('_global.json')
         for name, people in global_['groups'].iteritems():
             assert name not in groups, "group %s overlaps with _global.json" % name
             groups[name] = people

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -39,7 +39,6 @@ warning_summary = ':warning: **Warning** :warning:\n\n%s'
 submodule_warning_msg = 'These commits modify **submodules**.'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
 
-
 review_with_reviewer = 'r? @%s\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
 review_without_reviewer = '@%s: no appropriate reviewer found, use r? to override'
 

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -336,10 +336,10 @@ class HighfiveHandler(object):
         # no eligible reviewer found
         return (None, None)
 
-    def add_labels(self, labels, owner, repo, issue):
+    def add_labels(self, owner, repo, issue):
         api_req(
-            "POST", issue_labels_url % (owner, repo, issue), labels,
-            self.integration_token
+            'POST', issue_labels_url % (owner, repo, issue),
+            self.repo_config['new_pr_labels'], self.integration_token
         )
 
     def new_pr(self):
@@ -381,9 +381,7 @@ class HighfiveHandler(object):
         self.post_warnings(diff, owner, repo, issue)
 
         if self.repo_config.get("new_pr_labels"):
-            self.add_labels(
-                self.repo_config["new_pr_labels"], owner, repo, issue
-            )
+            self.add_labels(owner, repo, issue)
 
     def new_comment(self):
         # Check the issue is a PR and is open.

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -375,15 +375,16 @@ class HighfiveHandler(object):
 
         self.config = ConfigParser.RawConfigParser()
         self.config.read('./config')
+        self.integration_user = self.config.get('github', 'user')
+        self.integration_token = self.config.get('github', 'token')
 
     def run(self):
-        user = self.config.get('github', 'user')
-        token = self.config.get('github', 'token')
-
         if self.payload["action"] == "opened":
-            new_pr(self.payload, user, token)
+            new_pr(self.payload, self.integration_user, self.integration_token)
         elif self.payload["action"] == "created":
-            new_comment(self.payload, user, token)
+            new_comment(
+                self.payload, self.integration_user, self.integration_token
+            )
         else:
             print self.payload["action"]
             sys.exit(0)

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -369,20 +369,24 @@ def new_comment(payload, user, token):
         issue = str(payload['issue', 'number'])
         set_assignee(reviewer, owner, repo, issue, user, token, author, None)
 
+class HighfiveHandler(object):
+    def __init__(self, payload):
+        self.payload = payload
 
-def run(payload):
-    config = ConfigParser.RawConfigParser()
-    config.read('./config')
-    user = config.get('github', 'user')
-    token = config.get('github', 'token')
+        self.config = ConfigParser.RawConfigParser()
+        self.config.read('./config')
 
-    if payload["action"] == "opened":
-        new_pr(payload, user, token)
-    elif payload["action"] == "created":
-        new_comment(payload, user, token)
-    else:
-        print payload["action"]
-        sys.exit(0)
+    def run(self):
+        user = self.config.get('github', 'user')
+        token = self.config.get('github', 'token')
+
+        if self.payload["action"] == "opened":
+            new_pr(self.payload, user, token)
+        elif self.payload["action"] == "created":
+            new_comment(self.payload, user, token)
+        else:
+            print self.payload["action"]
+            sys.exit(0)
 
 
 if __name__ == "__main__":
@@ -393,4 +397,5 @@ if __name__ == "__main__":
 
     post = cgi.FieldStorage()
     payload_raw = post.getfirst("payload",'')
-    run(payload.Payload(json.loads(payload_raw)))
+    handler = HighfiveHandler(payload.Payload(json.loads(payload_raw)))
+    handler.run()

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -134,9 +134,6 @@ def is_collaborator(commenter, owner, repo, token):
         else:
             raise e
 
-def add_labels(labels, owner, repo, issue, token):
-    api_req("POST", issue_labels_url % (owner, repo, issue), labels, token)
-
 def get_irc_nick(gh_name):
     """ returns None if the request status code is not 200,
      if the user does not exist on the rustacean database,
@@ -339,6 +336,12 @@ class HighfiveHandler(object):
         # no eligible reviewer found
         return (None, None)
 
+    def add_labels(self, labels, owner, repo, issue):
+        api_req(
+            "POST", issue_labels_url % (owner, repo, issue), labels,
+            self.integration_token
+        )
+
     def new_pr(self):
         owner = self.payload['pull_request', 'base', 'repo', 'owner', 'login']
         repo = self.payload['pull_request', 'base', 'repo', 'name']
@@ -378,9 +381,8 @@ class HighfiveHandler(object):
         self.post_warnings(diff, owner, repo, issue)
 
         if self.repo_config.get("new_pr_labels"):
-            add_labels(
-                self.repo_config["new_pr_labels"], owner, repo, issue,
-                self.integration_token
+            self.add_labels(
+                self.repo_config["new_pr_labels"], owner, repo, issue
             )
 
     def new_comment(self):

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -137,11 +137,6 @@ def is_collaborator(commenter, owner, repo, token):
 def add_labels(labels, owner, repo, issue, token):
     api_req("POST", issue_labels_url % (owner, repo, issue), labels, token)
 
-# If the user specified a reviewer, return the username, otherwise returns None.
-def find_reviewer(msg):
-    match = reviewer_re.search(msg)
-    return match.group(1) if match else None
-
 def get_irc_nick(gh_name):
     """ returns None if the request status code is not 200,
      if the user does not exist on the rustacean database,
@@ -234,6 +229,14 @@ class HighfiveHandler(object):
                 return True
             else:
                 raise e
+
+    def find_reviewer(self, msg):
+        '''
+        If the user specified a reviewer, return the username, otherwise returns
+        None.
+        '''
+        match = reviewer_re.search(msg)
+        return match.group(1) if match else None
 
     def choose_reviewer(self, repo, owner, diff, exclude):
         '''Choose a reviewer for the PR.'''
@@ -348,7 +351,7 @@ class HighfiveHandler(object):
         )['body']
 
         msg = self.payload['pull_request', 'body']
-        reviewer = find_reviewer(msg)
+        reviewer = self.find_reviewer(msg)
         post_msg = False
         to_mention = None
 
@@ -408,7 +411,7 @@ class HighfiveHandler(object):
 
         # Check for r? and set the assignee.
         msg = self.payload['comment', 'body']
-        reviewer = find_reviewer(msg)
+        reviewer = self.find_reviewer(msg)
         if reviewer:
             issue = str(self.payload['issue', 'number'])
             set_assignee(

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -55,10 +55,6 @@ surprise_branch_warning = "Pull requests are usually filed against the %s branch
 review_with_reviewer = 'r? @%s\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
 review_without_reviewer = '@%s: no appropriate reviewer found, use r? to override'
 
-def review_msg(reviewer, submitter):
-    return review_without_reviewer % submitter if reviewer is None \
-        else review_with_reviewer % reviewer
-
 reviewer_re = re.compile("\\b[rR]\?[:\- ]*@([a-zA-Z0-9\-]+)")
 submodule_re = re.compile(".*\+Subproject\scommit\s.*", re.DOTALL|re.MULTILINE)
 
@@ -203,6 +199,10 @@ class HighfiveHandler(object):
                 pass
             else:
                 raise e
+
+    def review_msg(self, reviewer, submitter):
+        return review_without_reviewer % submitter if reviewer is None \
+            else review_with_reviewer % reviewer
 
     def unexpected_branch(self):
         """ returns (expected_branch, actual_branch) if they differ, else False
@@ -382,7 +382,7 @@ class HighfiveHandler(object):
             )
         elif post_msg:
             self.post_comment(
-                review_msg(reviewer, author), owner, repo, issue
+                self.review_msg(reviewer, author), owner, repo, issue
             )
 
         self.post_warnings(diff, owner, repo, issue)

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -35,18 +35,6 @@ If any changes to this PR are deemed necessary, please add them as extra commits
 Please see [the contribution instructions](%s) for more information.
 """
 
-
-def welcome_msg(reviewer, config):
-    if reviewer is None:
-        text = welcome_without_reviewer
-    else:
-        text = welcome_with_reviewer % reviewer
-    # Default to the Rust contribution guide if "contributing" wasn't set
-    link = config.get('contributing')
-    if not link:
-        link = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md"
-    return raw_welcome % (text, link)
-
 warning_summary = ':warning: **Warning** :warning:\n\n%s'
 submodule_warning_msg = 'These commits modify **submodules**.'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
@@ -199,6 +187,17 @@ class HighfiveHandler(object):
                 pass
             else:
                 raise e
+
+    def welcome_msg(self, reviewer):
+        if reviewer is None:
+            text = welcome_without_reviewer
+        else:
+            text = welcome_with_reviewer % reviewer
+        # Default to the Rust contribution guide if "contributing" wasn't set
+        link = self.repo_config.get('contributing')
+        if not link:
+            link = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md"
+        return raw_welcome % (text, link)
 
     def review_msg(self, reviewer, submitter):
         return review_without_reviewer % submitter if reviewer is None \
@@ -378,7 +377,7 @@ class HighfiveHandler(object):
 
         if self.is_new_contributor(author, owner, repo):
             self.post_comment(
-                welcome_msg(reviewer, self.repo_config), owner, repo, issue
+                self.welcome_msg(reviewer), owner, repo, issue
             )
         elif post_msg:
             self.post_comment(

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -142,9 +142,6 @@ def find_reviewer(msg):
     match = reviewer_re.search(msg)
     return match.group(1) if match else None
 
-def modifies_submodule(diff):
-    return submodule_re.match(diff)
-
 def get_irc_nick(gh_name):
     """ returns None if the request status code is not 200,
      if the user does not exist on the rustacean database,
@@ -190,6 +187,9 @@ class HighfiveHandler(object):
             print self.payload["action"]
             sys.exit(0)
 
+    def modifies_submodule(self, diff):
+        return submodule_re.match(diff)
+
     def post_warnings(self, diff, owner, repo, issue):
         warnings = []
 
@@ -197,7 +197,7 @@ class HighfiveHandler(object):
         if surprise:
             warnings.append(surprise_branch_warning % surprise)
 
-        if modifies_submodule(diff):
+        if self.modifies_submodule(diff):
             warnings.append(submodule_warning_msg)
 
         if warnings:

--- a/highfive/tests/fakes.py
+++ b/highfive/tests/fakes.py
@@ -11,6 +11,11 @@ def get_repo_configs():
             "groups": { "all": ["@pnkfelix", "@nrc"] },
             "dirs": {},
         },
+        'individuals_no_dirs_labels': {
+            "groups": { "all": ["@pnkfelix", "@nrc"] },
+            "dirs": {},
+            "new_pr_labels": ["a", "b"],
+        },
         'individuals_dirs': {
             "groups": { "all": ["@pnkfelix", "@nrc"] },
             "dirs": { "librustc": ["@aturon"] },

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -34,7 +34,7 @@ class TestIsNewContributor(base.BaseTest):
 class ApiReqMocker(object):
     def __init__(self, calls_and_returns):
         self.calls = [(c[0],) for c in calls_and_returns]
-        self.patcher = mock.patch('highfive.newpr.api_req')
+        self.patcher = mock.patch('highfive.newpr.HighfiveHandler.api_req')
         self.mock = self.patcher.start()
         self.mock.side_effect = [c[1] for c in calls_and_returns]
 
@@ -78,7 +78,7 @@ class TestNewPr(base.BaseTest):
         api_req_mock = ApiReqMocker([
             (
                 (
-                    'GET', 'https://the.url/', None, 'integration-token',
+                    'GET', 'https://the.url/', None,
                     'application/vnd.github.v3.diff'
                 ),
                 {'body': self._load_fake('normal.diff')},
@@ -86,22 +86,21 @@ class TestNewPr(base.BaseTest):
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '7'),
-                    {'assignee': 'nrc'}, 'integration-token'
+                    {'assignee': 'nrc'}
                 ),
                 {'body': {}},
             ),
             (
                 (
                     'GET', newpr.commit_search_url % ('rust-lang', 'rust', 'pnkfelix'),
-                    None, 'integration-token', 'application/vnd.github.cloak-preview'
+                    None, 'application/vnd.github.cloak-preview'
                 ),
                 {'body': '{"total_count": 0}'},
             ),
             (
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
-                    {'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md) for more information.\n"},
-                    'integration-token'
+                    {'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md) for more information.\n"}
                 ),
                 {'body': {}},
             ),
@@ -119,7 +118,7 @@ class TestNewPr(base.BaseTest):
         api_req_mock = ApiReqMocker([
             (
                 (
-                    'GET', 'https://the.url/', None, 'integration-token',
+                    'GET', 'https://the.url/', None,
                     'application/vnd.github.v3.diff'
                 ),
                 {'body': self._load_fake('normal.diff')},
@@ -127,23 +126,21 @@ class TestNewPr(base.BaseTest):
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '7'),
-                    {'assignee': 'nrc'}, 'integration-token'
+                    {'assignee': 'nrc'}
                 ),
                 {'body': {}},
             ),
             (
                 (
                     'GET', newpr.commit_search_url % ('rust-lang', 'rust', 'pnkfelix'),
-                    None, 'integration-token',
-                    'application/vnd.github.cloak-preview'
+                    None, 'application/vnd.github.cloak-preview'
                 ),
                 {'body': '{"total_count": 1}'},
             ),
             (
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
-                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'},
-                    'integration-token'
+                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'}
                 ),
                 {'body': {}},
             ),
@@ -165,7 +162,7 @@ class TestNewPr(base.BaseTest):
         api_req_mock = ApiReqMocker([
             (
                 (
-                    'GET', 'https://the.url/', None, 'integration-token',
+                    'GET', 'https://the.url/', None,
                     'application/vnd.github.v3.diff'
                 ),
                 {'body': self._load_fake('normal.diff')},
@@ -173,30 +170,28 @@ class TestNewPr(base.BaseTest):
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '7'),
-                    {'assignee': 'nrc'}, 'integration-token'
+                    {'assignee': 'nrc'}
                 ),
                 {'body': {}},
             ),
             (
                 (
                     'GET', newpr.commit_search_url % ('rust-lang', 'rust', 'pnkfelix'),
-                    None, 'integration-token',
-                    'application/vnd.github.cloak-preview'
+                    None, 'application/vnd.github.cloak-preview'
                 ),
                 {'body': '{"total_count": 1}'},
             ),
             (
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
-                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'},
-                    'integration-token'
+                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'}
                 ),
                 {'body': {}},
             ),
             (
                 (
                     'POST', newpr.issue_labels_url % ('rust-lang', 'rust', '7'),
-                    ['a', 'b'], 'integration-token'
+                    ['a', 'b']
                 ),
                 {'body': {}},
             ),
@@ -227,7 +222,7 @@ class TestNewComment(base.BaseTest):
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '1'),
-                    {'assignee': 'davidalber'}, 'integration-token'
+                    {'assignee': 'davidalber'}
                 ),
                 {'body': {}},
             ),
@@ -247,14 +242,14 @@ class TestNewComment(base.BaseTest):
                     newpr.user_collabo_url % (
                         'rust-lang', 'rust', 'davidalber'
                     ),
-                    None, 'integration-token'
+                    None
                 ),
                 {'body': {}},
             ),
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '1'),
-                    {'assignee': 'davidalber'}, 'integration-token'
+                    {'assignee': 'davidalber'}
                 ),
                 {'body': {}},
             ),

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -156,9 +156,14 @@ class TestNewComment(base.BaseTest):
     def setUp(self):
         super(TestNewComment, self).setUp((
             ('get_irc_nick', 'highfive.newpr.get_irc_nick'),
+            ('ConfigParser', 'highfive.newpr.ConfigParser'),
         ))
 
         self.mocks['get_irc_nick'].return_value = None
+
+        config_mock = mock.Mock()
+        config_mock.get.side_effect = ('integration-user', 'integration-token')
+        self.mocks['ConfigParser'].RawConfigParser.return_value = config_mock
 
     def test_author_is_commenter(self):
         payload = fakes.Payload.new_comment()
@@ -167,7 +172,7 @@ class TestNewComment(base.BaseTest):
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '1'),
-                    {'assignee': 'davidalber'}, 'integrationToken'
+                    {'assignee': 'davidalber'}, 'integration-token'
                 ),
                 {'body': {}},
             ),

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -53,7 +53,7 @@ class ApiReqMocker(object):
 class TestNewPr(base.BaseTest):
     def setUp(self):
         super(TestNewPr, self).setUp((
-            ('get_irc_nick', 'highfive.newpr.get_irc_nick'),
+            ('get_irc_nick', 'highfive.newpr.HighfiveHandler.get_irc_nick'),
             ('ConfigParser', 'highfive.newpr.ConfigParser'),
             ('load_json_file', 'highfive.newpr._load_json_file'),
         ))
@@ -210,7 +210,7 @@ class TestNewPr(base.BaseTest):
 class TestNewComment(base.BaseTest):
     def setUp(self):
         super(TestNewComment, self).setUp((
-            ('get_irc_nick', 'highfive.newpr.get_irc_nick'),
+            ('get_irc_nick', 'highfive.newpr.HighfiveHandler.get_irc_nick'),
             ('ConfigParser', 'highfive.newpr.ConfigParser'),
         ))
 

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -1,5 +1,6 @@
 from highfive import newpr, payload
 from highfive.tests import base, fakes
+from highfive.tests.test_newpr import HighfiveHandlerMock
 import mock
 from nose.plugins.attrib import attr
 
@@ -9,25 +10,24 @@ class TestIsNewContributor(base.BaseTest):
         super(TestIsNewContributor, self).setUp()
 
         self.payload = payload.Payload({'repository': {'fork': False}})
+        self.handler = HighfiveHandlerMock(
+            self.payload, integration_token=''
+        ).handler
 
     def test_real_contributor_true(self):
         self.assertFalse(
-            newpr.is_new_contributor(
-                'nrc', 'rust-lang', 'rust', '', self.payload
-            )
+            self.handler.is_new_contributor('nrc', 'rust-lang', 'rust')
         )
 
     def test_real_contributor_false(self):
         self.assertTrue(
-            newpr.is_new_contributor(
-                'octocat', 'rust-lang', 'rust', '', self.payload
-            )
+            self.handler.is_new_contributor('octocat', 'rust-lang', 'rust')
         )
 
     def test_fake_user(self):
         self.assertTrue(
-            newpr.is_new_contributor(
-                'fjkesfgojsrgljsdgla', 'rust-lang', 'rust', '', self.payload
+            self.handler.is_new_contributor(
+                'fjkesfgojsrgljsdgla', 'rust-lang', 'rust'
             )
         )
 

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -73,6 +73,7 @@ class TestNewPr(base.BaseTest):
         payload = fakes.Payload.new_pr(
             repo_owner='rust-lang', repo_name='rust', pr_author='pnkfelix'
         )
+        handler = newpr.HighfiveHandler(payload)
 
         api_req_mock = ApiReqMocker([
             (
@@ -105,7 +106,7 @@ class TestNewPr(base.BaseTest):
                 {'body': {}},
             ),
         ])
-        newpr.new_pr(payload, 'integration-user', 'integration-token')
+        handler.new_pr()
 
         api_req_mock.verify_calls()
 
@@ -113,6 +114,7 @@ class TestNewPr(base.BaseTest):
         payload = fakes.Payload.new_pr(
             repo_owner='rust-lang', repo_name='rust', pr_author='pnkfelix'
         )
+        handler = newpr.HighfiveHandler(payload)
 
         api_req_mock = ApiReqMocker([
             (
@@ -146,7 +148,7 @@ class TestNewPr(base.BaseTest):
                 {'body': {}},
             ),
         ])
-        newpr.new_pr(payload, 'integration-user', 'integration-token')
+        handler.new_pr()
 
         api_req_mock.verify_calls()
 

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -55,7 +55,7 @@ class TestNewPr(base.BaseTest):
         super(TestNewPr, self).setUp((
             ('get_irc_nick', 'highfive.newpr.HighfiveHandler.get_irc_nick'),
             ('ConfigParser', 'highfive.newpr.ConfigParser'),
-            ('load_json_file', 'highfive.newpr._load_json_file'),
+            ('load_json_file', 'highfive.newpr.HighfiveHandler._load_json_file'),
         ))
 
         self.mocks['get_irc_nick'].return_value = None

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -1,6 +1,5 @@
 from highfive import newpr, payload
 from highfive.tests import base, fakes
-from highfive.tests.test_newpr import HighfiveHandlerMock
 import mock
 from nose.plugins.attrib import attr
 
@@ -163,14 +162,15 @@ class TestNewComment(base.BaseTest):
 
     def test_author_is_commenter(self):
         payload = fakes.Payload.new_comment()
+        handler = newpr.HighfiveHandler(payload)
         api_req_mock = ApiReqMocker([
             (
                 (
                     'PATCH', newpr.issue_url % ('rust-lang', 'rust', '1'),
-                    {'assignee': 'davidalber'}, 'integration-token'
+                    {'assignee': 'davidalber'}, 'integrationToken'
                 ),
                 {'body': {}},
             ),
         ])
-        newpr.new_comment(payload, 'integration-user', 'integration-token')
+        handler.new_comment()
         api_req_mock.verify_calls()

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -234,3 +234,30 @@ class TestNewComment(base.BaseTest):
         ])
         handler.new_comment()
         api_req_mock.verify_calls()
+
+    def test_author_not_commenter_is_collaborator(self):
+        payload = fakes.Payload.new_comment()
+        payload._payload['issue']['user']['login'] = 'foouser'
+
+        handler = newpr.HighfiveHandler(payload)
+        api_req_mock = ApiReqMocker([
+            (
+                (
+                    "GET",
+                    newpr.user_collabo_url % (
+                        'rust-lang', 'rust', 'davidalber'
+                    ),
+                    None, 'integration-token'
+                ),
+                {'body': {}},
+            ),
+            (
+                (
+                    'PATCH', newpr.issue_url % ('rust-lang', 'rust', '1'),
+                    {'assignee': 'davidalber'}, 'integration-token'
+                ),
+                {'body': {}},
+            ),
+        ])
+        handler.new_comment()
+        api_req_mock.verify_calls()

--- a/highfive/tests/integration_tests.py
+++ b/highfive/tests/integration_tests.py
@@ -1,5 +1,6 @@
 from highfive import newpr, payload
 from highfive.tests import base, fakes
+from highfive.tests.test_newpr import HighfiveHandlerMock
 import mock
 from nose.plugins.attrib import attr
 
@@ -105,7 +106,7 @@ class TestNewPr(base.BaseTest):
                 {'body': {}},
             ),
         ])
-        newpr.run(payload)
+        newpr.new_pr(payload, 'integration-user', 'integration-token')
 
         api_req_mock.verify_calls()
 
@@ -146,7 +147,7 @@ class TestNewPr(base.BaseTest):
                 {'body': {}},
             ),
         ])
-        newpr.run(payload)
+        newpr.new_pr(payload, 'integration-user', 'integration-token')
 
         api_req_mock.verify_calls()
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -140,14 +140,15 @@ Please see [the contribution instructions](%s) for more information.
 
     def test_review_msg(self):
         # No reviewer.
+        handler = HighfiveHandlerMock(Payload({})).handler
         self.assertEqual(
-            newpr.review_msg(None, 'userB'),
+            handler.review_msg(None, 'userB'),
             '@userB: no appropriate reviewer found, use r? to override'
         )
 
         # Has reviewer.
         self.assertEqual(
-            newpr.review_msg('userA', 'userB'),
+            handler.review_msg('userA', 'userB'),
             'r? @userA\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
         )
 
@@ -822,7 +823,7 @@ class TestNewPrFunction(TestNewPR):
             ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
             ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
             ('welcome_msg', 'highfive.newpr.welcome_msg'),
-            ('review_msg', 'highfive.newpr.review_msg'),
+            ('review_msg', 'highfive.newpr.HighfiveHandler.review_msg'),
             ('post_warnings', 'highfive.newpr.HighfiveHandler.post_warnings'),
             ('add_labels', 'highfive.newpr.HighfiveHandler.add_labels'),
         ))

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -203,42 +203,41 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('highfive.newpr.api_req')
     def test_is_collaborator_true(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         self.assertTrue(
-            newpr.is_collaborator(
-                'commentUser', 'repo-owner', 'repo-name', 'credential'
-            )
+            handler.is_collaborator('commentUser', 'repo-owner', 'repo-name')
         )
         mock_api_req.assert_called_with(
             'GET',
             'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
-            None, 'credential'
+            None, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
     def test_is_collaborator_false(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_api_req.side_effect = HTTPError(None, 404, None, None, None)
         self.assertFalse(
-            newpr.is_collaborator(
-                'commentUser', 'repo-owner', 'repo-name', 'credential'
-            )
+            handler.is_collaborator('commentUser', 'repo-owner', 'repo-name')
         )
         mock_api_req.assert_called_with(
             'GET',
             'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
-            None, 'credential'
+            None, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
     def test_is_collaborator_error(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_api_req.side_effect = HTTPError(None, 500, None, None, None)
         self.assertRaises(
-            HTTPError, newpr.is_collaborator, 'commentUser', 'repo-owner',
-            'repo-name', 'credential'
+            HTTPError, handler.is_collaborator, 'commentUser', 'repo-owner',
+            'repo-name'
         )
         mock_api_req.assert_called_with(
             'GET',
             'https://api.github.com/repos/repo-owner/repo-name/collaborators/commentUser',
-            None, 'credential'
+            None, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
@@ -953,7 +952,7 @@ class TestNewPrFunction(TestNewPR):
 class TestNewComment(TestNewPR):
     def setUp(self):
         super(TestNewComment, self).setUp((
-            ('is_collaborator', 'highfive.newpr.is_collaborator'),
+            ('is_collaborator', 'highfive.newpr.HighfiveHandler.is_collaborator'),
             ('find_reviewer', 'highfive.newpr.HighfiveHandler.find_reviewer'),
             ('set_assignee', 'highfive.newpr.set_assignee'),
         ))
@@ -1026,7 +1025,7 @@ class TestNewComment(TestNewPR):
         self.mocks['is_collaborator'].return_value = False
         self.assertIsNone(handler.new_comment())
         self.mocks['is_collaborator'].assert_called_with(
-            'userB', 'repo-owner', 'repo-name', 'integrationToken'
+            'userB', 'repo-owner', 'repo-name'
         )
         self.mocks['find_reviewer'].assert_not_called()
         self.mocks['set_assignee'].assert_not_called()
@@ -1059,7 +1058,7 @@ class TestNewComment(TestNewPR):
         self.mocks['is_collaborator'].return_value = True
         handler.new_comment()
         self.mocks['is_collaborator'].assert_called_with(
-            'userB', 'repo-owner', 'repo-name', 'integrationToken'
+            'userB', 'repo-owner', 'repo-name'
         )
         self.mocks['find_reviewer'].assert_called()
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -244,29 +244,31 @@ Please see [the contribution instructions](%s) for more information.
     @mock.patch('highfive.newpr.api_req')
     def test_add_labels_success(self, mock_api_req):
         mock_api_req.return_value = {'body': 'response body!'}
+        handler = HighfiveHandlerMock(Payload({})).handler
         labels = ['label1', 'label2']
         self.assertIsNone(
-            newpr.add_labels(
-                labels, 'repo-owner', 'repo-name', 7, 'credential'
+            handler.add_labels(
+                labels, 'repo-owner', 'repo-name', 7
             )
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
-            labels, 'credential'
+            labels, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
     def test_add_labels_error(self, mock_api_req):
         mock_api_req.return_value = {}
         mock_api_req.side_effect = HTTPError(None, 422, None, None, None)
+        handler = HighfiveHandlerMock(Payload({})).handler
         labels = ['label1', 'label2']
         self.assertRaises(
-            HTTPError, newpr.add_labels, labels, 'repo-owner', 'repo-name',
-            7, 'credential'
+            HTTPError, handler.add_labels, labels, 'repo-owner', 'repo-name',
+            7
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
-            labels, 'credential'
+            labels, 'integrationToken'
         )
 
     def test_submodule(self):
@@ -815,7 +817,7 @@ class TestNewPrFunction(TestNewPR):
             ('welcome_msg', 'highfive.newpr.welcome_msg'),
             ('review_msg', 'highfive.newpr.review_msg'),
             ('post_warnings', 'highfive.newpr.HighfiveHandler.post_warnings'),
-            ('add_labels', 'highfive.newpr.add_labels'),
+            ('add_labels', 'highfive.newpr.HighfiveHandler.add_labels'),
         ))
 
         self.mocks['api_req'].return_value = {'body': 'diff'}
@@ -865,7 +867,7 @@ class TestNewPrFunction(TestNewPR):
             'Welcome!', 'repo-owner', 'repo-name', '7', self.token
         )
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7', self.token
+            ['foo-label'], 'repo-owner', 'repo-name', '7'
         )
 
     def test_no_msg_reviewer_repeat_contributor(self):
@@ -890,7 +892,7 @@ class TestNewPrFunction(TestNewPR):
             'Review message!', 'repo-owner', 'repo-name', '7', self.token
         )
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7', self.token
+            ['foo-label'], 'repo-owner', 'repo-name', '7'
         )
 
     def test_msg_reviewer_repeat_contributor(self):
@@ -906,7 +908,7 @@ class TestNewPrFunction(TestNewPR):
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_not_called()
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7', self.token
+            ['foo-label'], 'repo-owner', 'repo-name', '7'
         )
 
     def test_no_pr_labels_specified(self):

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -244,13 +244,11 @@ Please see [the contribution instructions](%s) for more information.
     @mock.patch('highfive.newpr.api_req')
     def test_add_labels_success(self, mock_api_req):
         mock_api_req.return_value = {'body': 'response body!'}
-        handler = HighfiveHandlerMock(Payload({})).handler
         labels = ['label1', 'label2']
-        self.assertIsNone(
-            handler.add_labels(
-                labels, 'repo-owner', 'repo-name', 7
-            )
-        )
+        handler = HighfiveHandlerMock(
+            Payload({}), repo_config={'new_pr_labels': labels}
+        ).handler
+        self.assertIsNone(handler.add_labels('repo-owner', 'repo-name', 7))
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
             labels, 'integrationToken'
@@ -260,11 +258,12 @@ Please see [the contribution instructions](%s) for more information.
     def test_add_labels_error(self, mock_api_req):
         mock_api_req.return_value = {}
         mock_api_req.side_effect = HTTPError(None, 422, None, None, None)
-        handler = HighfiveHandlerMock(Payload({})).handler
         labels = ['label1', 'label2']
+        handler = HighfiveHandlerMock(
+            Payload({}), repo_config={'new_pr_labels': labels}
+        ).handler
         self.assertRaises(
-            HTTPError, handler.add_labels, labels, 'repo-owner', 'repo-name',
-            7
+            HTTPError, handler.add_labels, 'repo-owner', 'repo-name', 7
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/labels',
@@ -867,7 +866,7 @@ class TestNewPrFunction(TestNewPR):
             'Welcome!', 'repo-owner', 'repo-name', '7', self.token
         )
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7'
+            'repo-owner', 'repo-name', '7'
         )
 
     def test_no_msg_reviewer_repeat_contributor(self):
@@ -892,7 +891,7 @@ class TestNewPrFunction(TestNewPR):
             'Review message!', 'repo-owner', 'repo-name', '7', self.token
         )
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7'
+            'repo-owner', 'repo-name', '7'
         )
 
     def test_msg_reviewer_repeat_contributor(self):
@@ -908,7 +907,7 @@ class TestNewPrFunction(TestNewPR):
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_not_called()
         self.mocks['add_labels'].assert_called_once_with(
-            ['foo-label'], 'repo-owner', 'repo-name', '7'
+            'repo-owner', 'repo-name', '7'
         )
 
     def test_no_pr_labels_specified(self):

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -271,35 +271,31 @@ Please see [the contribution instructions](%s) for more information.
         payload = Payload(
             {'pull_request': {'base': {'label': 'repo-owner:dev'}}}
         )
-        config = {}
-        self.assertEqual(
-            newpr.unexpected_branch(payload, config),
-            ('master', 'dev')
-        )
+        with HighfiveHandlerMock(payload, repo_config={}) as m:
+            self.assertEqual(m.handler.unexpected_branch(), ('master', 'dev'))
 
     def test_expected_branch_default_expected_match(self):
         payload = Payload(
             {'pull_request': {'base': {'label': 'repo-owner:master'}}}
         )
-        config = {}
-        self.assertFalse(newpr.unexpected_branch(payload, config))
+        with HighfiveHandlerMock(payload, repo_config={}) as m:
+            self.assertFalse(m.handler.unexpected_branch())
 
     def test_expected_branch_custom_expected_no_match(self):
         payload = Payload(
             {'pull_request': {'base': {'label': 'repo-owner:master'}}}
         )
         config = {'expected_branch': 'dev' }
-        self.assertEqual(
-            newpr.unexpected_branch(payload, config),
-            ('dev', 'master')
-        )
+        with HighfiveHandlerMock(payload, repo_config=config) as m:
+            self.assertEqual(m.handler.unexpected_branch(), ('dev', 'master'))
 
     def test_expected_branch_custom_expected_match(self):
         payload = Payload(
             {'pull_request': {'base': {'label':'repo-owner:dev'}}}
         )
         config = {'expected_branch': 'dev' }
-        self.assertFalse(newpr.unexpected_branch(payload, config))
+        with HighfiveHandlerMock(payload, repo_config=config) as m:
+            self.assertFalse(m.handler.unexpected_branch())
 
     def test_find_reviewer(self):
         found_cases = (
@@ -710,7 +706,7 @@ class TestPostWarnings(TestNewPR):
 
     def setUp(self):
         super(TestPostWarnings, self).setUp((
-            ('unexpected_branch', 'highfive.newpr.unexpected_branch'),
+            ('unexpected_branch', 'highfive.newpr.HighfiveHandler.unexpected_branch'),
             ('modifies_submodule', 'highfive.newpr.modifies_submodule'),
             ('post_comment', 'highfive.newpr.post_comment'),
         ))
@@ -730,9 +726,7 @@ class TestPostWarnings(TestNewPR):
 
         self.post_warnings()
 
-        self.mocks['unexpected_branch'].assert_called_with(
-            self.payload, self.config
-        )
+        self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
         self.mocks['post_comment'].assert_not_called()
 
@@ -744,9 +738,7 @@ class TestPostWarnings(TestNewPR):
 
         self.post_warnings()
 
-        self.mocks['unexpected_branch'].assert_called_with(
-            self.payload, self.config
-        )
+        self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
@@ -762,9 +754,7 @@ class TestPostWarnings(TestNewPR):
 
         self.post_warnings()
 
-        self.mocks['unexpected_branch'].assert_called_with(
-            self.payload, self.config
-        )
+        self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
@@ -782,9 +772,7 @@ class TestPostWarnings(TestNewPR):
 
         self.post_warnings()
 
-        self.mocks['unexpected_branch'].assert_called_with(
-            self.payload, self.config
-        )
+        self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -536,7 +536,7 @@ class TestSetAssignee(TestNewPR):
         cls.repo = 'repo-name'
         cls.issue = 7
         cls.user = 'integrationUser'
-        cls.token = 'credential'
+        cls.token = 'integrationToken'
 
     def setUp(self):
         super(TestSetAssignee, self).setUp((
@@ -548,10 +548,12 @@ class TestSetAssignee(TestNewPR):
 
         self.mocks['client'] = self.mocks['IrcClient'].return_value
 
+        self.handler = HighfiveHandlerMock(Payload({})).handler
+
     def set_assignee(self, assignee='', to_mention=None):
         assignee = self.assignee if assignee == '' else assignee
-        return newpr.set_assignee(
-            assignee, self.owner, self.repo, self.issue, self.user, self.token,
+        return self.handler.set_assignee(
+            assignee, self.owner, self.repo, self.issue, self.user,
             self.author, to_mention or []
         )
 
@@ -809,7 +811,7 @@ class TestNewPrFunction(TestNewPR):
             ('api_req', 'highfive.newpr.api_req'),
             ('find_reviewer', 'highfive.newpr.HighfiveHandler.find_reviewer'),
             ('choose_reviewer', 'highfive.newpr.HighfiveHandler.choose_reviewer'),
-            ('set_assignee', 'highfive.newpr.set_assignee'),
+            ('set_assignee', 'highfive.newpr.HighfiveHandler.set_assignee'),
             ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
             ('post_comment', 'highfive.newpr.post_comment'),
             ('welcome_msg', 'highfive.newpr.welcome_msg'),
@@ -833,8 +835,8 @@ class TestNewPrFunction(TestNewPR):
         )
         self.mocks['find_reviewer'].assert_called_once_with('The PR comment.')
         self.mocks['set_assignee'].assert_called_once_with(
-            reviewer, 'repo-owner', 'repo-name', '7', self.user, self.token,
-            'prAuthor', to_mention
+            reviewer, 'repo-owner', 'repo-name', '7', self.user, 'prAuthor',
+            to_mention
         )
         self.mocks['is_new_contributor'].assert_called_once_with(
             'prAuthor', 'repo-owner', 'repo-name'
@@ -954,7 +956,7 @@ class TestNewComment(TestNewPR):
         super(TestNewComment, self).setUp((
             ('is_collaborator', 'highfive.newpr.HighfiveHandler.is_collaborator'),
             ('find_reviewer', 'highfive.newpr.HighfiveHandler.find_reviewer'),
-            ('set_assignee', 'highfive.newpr.set_assignee'),
+            ('set_assignee', 'highfive.newpr.HighfiveHandler.set_assignee'),
         ))
 
     @staticmethod
@@ -1080,7 +1082,7 @@ class TestNewComment(TestNewPR):
         self.mocks['find_reviewer'].assert_called_with('comment!')
         self.mocks['set_assignee'].assert_called_with(
             'userD', 'repo-owner', 'repo-name', '7', 'integrationUser',
-            'integrationToken', 'userA', None
+            'userA', None
         )
 
 class TestChooseReviewer(TestNewPR):

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -325,16 +325,17 @@ Please see [the contribution instructions](%s) for more information.
             'r? foo',
             'r? @',
         )
+        handler = HighfiveHandlerMock(Payload({})).handler
 
         for (msg, reviewer) in found_cases:
             self.assertEqual(
-                newpr.find_reviewer(msg), reviewer,
+                handler.find_reviewer(msg), reviewer,
                 "expected '%s' from '%s'" % (reviewer, msg)
             )
 
         for msg in not_found_cases:
             self.assertIsNone(
-                newpr.find_reviewer(msg),
+                handler.find_reviewer(msg),
                 "expected '%s' to have no reviewer extracted" % msg
             )
 
@@ -806,7 +807,7 @@ class TestNewPrFunction(TestNewPR):
     def setUp(self):
         super(TestNewPrFunction, self).setUp((
             ('api_req', 'highfive.newpr.api_req'),
-            ('find_reviewer', 'highfive.newpr.find_reviewer'),
+            ('find_reviewer', 'highfive.newpr.HighfiveHandler.find_reviewer'),
             ('choose_reviewer', 'highfive.newpr.HighfiveHandler.choose_reviewer'),
             ('set_assignee', 'highfive.newpr.set_assignee'),
             ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
@@ -952,7 +953,7 @@ class TestNewComment(TestNewPR):
     def setUp(self):
         super(TestNewComment, self).setUp((
             ('is_collaborator', 'highfive.newpr.is_collaborator'),
-            ('find_reviewer', 'highfive.newpr.find_reviewer'),
+            ('find_reviewer', 'highfive.newpr.HighfiveHandler.find_reviewer'),
             ('set_assignee', 'highfive.newpr.set_assignee'),
         ))
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -767,7 +767,8 @@ class TestNewPrFunction(TestNewPR):
         cls.payload = fakes.Payload.new_pr()
 
         cls.user = 'integrationUser'
-        cls.token = 'credential'
+        cls.token = 'integrationToken'
+
 
     def setUp(self):
         super(TestNewPrFunction, self).setUp((
@@ -787,8 +788,10 @@ class TestNewPrFunction(TestNewPR):
         self.mocks['api_req'].return_value = {'body': 'diff'}
         self.mocks['load_json_file'].return_value = self.config
 
+        self.handler = HighfiveHandlerMock(self.payload).handler
+
     def call_new_pr(self):
-        return newpr.new_pr(self.payload, self.user, self.token)
+        return self.handler.new_pr()
 
     def assert_fixed_calls(self, reviewer, to_mention):
         self.mocks['api_req'].assert_called_once_with(
@@ -1220,7 +1223,7 @@ class TestChooseReviewer(TestNewPR):
 class TestRun(TestNewPR):
     def setUp(self):
         super(TestRun, self).setUp((
-            ('new_pr', 'highfive.newpr.new_pr'),
+            ('new_pr', 'highfive.newpr.HighfiveHandler.new_pr'),
             ('new_comment', 'highfive.newpr.HighfiveHandler.new_comment'),
             ('sys', 'highfive.newpr.sys'),
         ))
@@ -1235,9 +1238,7 @@ class TestRun(TestNewPR):
         m = self.handler_mock(payload)
         m.handler.run()
         self.assertEqual(m.mock_config.get.call_count, 2)
-        self.mocks['new_pr'].assert_called_once_with(
-            payload, 'integration-user', 'integration-token'
-        )
+        self.mocks['new_pr'].assert_called_once_with()
         self.mocks['new_comment'].assert_not_called()
         self.mocks['sys'].exit.assert_not_called()
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -47,6 +47,8 @@ class TestHighfiveHandler(TestNewPR):
         with HighfiveHandlerMock(payload) as m:
             self.assertEqual(m.handler.payload, payload)
             self.assertEqual(m.handler.config, m.mock_config)
+            self.assertEqual(m.handler.integration_user, 'integrationUser')
+            self.assertEqual(m.handler.integration_token, 'integrationToken')
             m.mock_config.read.assert_called_once_with('./config')
 
 class TestNewPRGeneral(TestNewPR):

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -70,7 +70,7 @@ class TestHighfiveHandler(TestNewPR):
             self.assertEqual(m.handler.repo_config, {'a': 'config!'})
             m.mock_config.read.assert_called_once_with('./config')
 
-    @mock.patch('highfive.newpr._load_json_file')
+    @mock.patch('highfive.newpr.HighfiveHandler._load_json_file')
     def test_load_repo_config_new_pr(self, mock_load_json_file):
         mock_load_json_file.return_value = {'a': 'config!'}
         payload = Payload({
@@ -82,7 +82,7 @@ class TestHighfiveHandler(TestNewPR):
         self.assertEqual(m.handler.load_repo_config(), {'a': 'config!'})
         mock_load_json_file.assert_called_once_with('blah.json')
 
-    @mock.patch('highfive.newpr._load_json_file')
+    @mock.patch('highfive.newpr.HighfiveHandler._load_json_file')
     def test_load_repo_config_not_new_pr(self, mock_load_json_file):
         payload = Payload({
             'action': 'created',
@@ -153,12 +153,13 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('os.path.dirname')
     def test_load_json_file(self, mock_dirname):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_dirname.return_value = '/the/path'
         contents = ['some json']
         with mock.patch(
             '__builtin__.open', mock.mock_open(read_data=json.dumps(contents))
         ) as mock_file:
-            self.assertEqual(newpr._load_json_file('a-config.json'), contents)
+            self.assertEqual(handler._load_json_file('a-config.json'), contents)
             mock_file.assert_called_with('/the/path/configs/a-config.json')
 
     @mock.patch('highfive.newpr.api_req')
@@ -1107,7 +1108,7 @@ class TestChooseReviewer(TestNewPR):
             repo, owner, diff, exclude, global_
         )
 
-    @mock.patch('highfive.newpr._load_json_file')
+    @mock.patch('highfive.newpr.HighfiveHandler._load_json_file')
     def choose_reviewer_inner(
         self, repo, owner, diff, exclude, global_, mock_load_json
     ):
@@ -1213,7 +1214,7 @@ class TestChooseReviewer(TestNewPR):
         self.assertEqual(set(['alexcrichton']), chosen_reviewers)
         self.assertEqual(set([()]), mentions)
 
-    @mock.patch('highfive.newpr._load_json_file')
+    @mock.patch('highfive.newpr.HighfiveHandler._load_json_file')
     def test_global_group_overlap(self, mock_load_json):
         """Test for an AssertionError when the global config contains a group
         already defined in the config.

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -649,7 +649,7 @@ class TestIsNewContributor(TestNewPR):
         cls.username = 'commitUser'
         cls.owner = 'repo-owner'
         cls.repo = 'repo-name'
-        cls.token = 'credential'
+        cls.token = 'integrationToken'
 
     def setUp(self):
         super(TestIsNewContributor, self).setUp((
@@ -658,9 +658,8 @@ class TestIsNewContributor(TestNewPR):
         self.payload = Payload({'repository': {'fork': False}})
 
     def is_new_contributor(self):
-        return newpr.is_new_contributor(
-            self.username, self.owner, self.repo, self.token, self.payload
-        )
+        handler = HighfiveHandlerMock(Payload(self.payload)).handler
+        return handler.is_new_contributor(self.username, self.owner, self.repo)
 
     def api_return(self, total_count):
         return {
@@ -809,7 +808,7 @@ class TestNewPrFunction(TestNewPR):
             ('find_reviewer', 'highfive.newpr.find_reviewer'),
             ('choose_reviewer', 'highfive.newpr.HighfiveHandler.choose_reviewer'),
             ('set_assignee', 'highfive.newpr.set_assignee'),
-            ('is_new_contributor', 'highfive.newpr.is_new_contributor'),
+            ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
             ('post_comment', 'highfive.newpr.post_comment'),
             ('welcome_msg', 'highfive.newpr.welcome_msg'),
             ('review_msg', 'highfive.newpr.review_msg'),
@@ -836,7 +835,7 @@ class TestNewPrFunction(TestNewPR):
             'prAuthor', to_mention
         )
         self.mocks['is_new_contributor'].assert_called_once_with(
-            'prAuthor', 'repo-owner', 'repo-name', self.token, self.payload
+            'prAuthor', 'repo-owner', 'repo-name'
         )
         self.mocks['post_warnings'].assert_called_once_with(
             'diff', 'repo-owner', 'repo-name', '7'

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -17,6 +17,7 @@ class HighfiveHandlerMock(object):
         self, payload, integration_user='integrationUser',
         integration_token='integrationToken', repo_config={}
     ):
+        assert(type(payload) == Payload)
         self.integration_user = integration_user
         self.integration_token = integration_token
 
@@ -1264,7 +1265,7 @@ class TestRun(TestNewPR):
         )
 
     def test_newpr(self):
-        payload = {'action': 'opened'}
+        payload = Payload({'action': 'opened'})
         m = self.handler_mock(payload)
         m.handler.run()
         self.assertEqual(m.mock_config.get.call_count, 2)
@@ -1273,7 +1274,7 @@ class TestRun(TestNewPR):
         self.mocks['sys'].exit.assert_not_called()
 
     def test_new_comment(self):
-        payload = {'action': 'created'}
+        payload = Payload({'action': 'created'})
         m = self.handler_mock(payload)
         m.handler.run()
         self.assertEqual(m.mock_config.get.call_count, 2)
@@ -1282,7 +1283,7 @@ class TestRun(TestNewPR):
         self.mocks['sys'].exit.assert_not_called()
 
     def test_unsupported_payload(self):
-        payload = {'action': 'something-not-supported'}
+        payload = Payload({'action': 'something-not-supported'})
         m = self.handler_mock(payload)
         m.handler.run()
         self.assertEqual(m.mock_config.get.call_count, 2)

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -103,8 +103,9 @@ Please see [the contribution instructions](%s) for more information.
 """
 
         # No reviewer, no config contributing link.
+        handler = HighfiveHandlerMock(Payload({})).handler
         self.assertEqual(
-            newpr.welcome_msg(None, {}),
+            handler.welcome_msg(None),
             base_msg % (
                 '@nrc (NB. this repo may be misconfigured)',
                 'https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md'
@@ -112,8 +113,9 @@ Please see [the contribution instructions](%s) for more information.
         )
 
         # Has reviewer, no config contributing link.
+        handler = HighfiveHandlerMock(Payload({})).handler
         self.assertEqual(
-            newpr.welcome_msg('userA', {}),
+            handler.welcome_msg('userA'),
             base_msg % (
                 '@userA (or someone else)',
                 'https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md'
@@ -121,8 +123,11 @@ Please see [the contribution instructions](%s) for more information.
         )
 
         # No reviewer, has config contributing link.
+        handler = HighfiveHandlerMock(
+            Payload({}), repo_config={'contributing': 'https://something'}
+        ).handler
         self.assertEqual(
-            newpr.welcome_msg(None, {'contributing': 'https://something'}),
+            handler.welcome_msg(None),
             base_msg % (
                 '@nrc (NB. this repo may be misconfigured)',
                 'https://something'
@@ -130,8 +135,11 @@ Please see [the contribution instructions](%s) for more information.
         )
 
         # Has reviewer, has config contributing link.
+        handler = HighfiveHandlerMock(
+            Payload({}), repo_config={'contributing': 'https://something'}
+        ).handler
         self.assertEqual(
-            newpr.welcome_msg('userA', {'contributing': 'https://something'}),
+            handler.welcome_msg('userA'),
             base_msg % (
                 '@userA (or someone else)',
                 'https://something'
@@ -822,7 +830,7 @@ class TestNewPrFunction(TestNewPR):
             ('set_assignee', 'highfive.newpr.HighfiveHandler.set_assignee'),
             ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
             ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
-            ('welcome_msg', 'highfive.newpr.welcome_msg'),
+            ('welcome_msg', 'highfive.newpr.HighfiveHandler.welcome_msg'),
             ('review_msg', 'highfive.newpr.HighfiveHandler.review_msg'),
             ('post_warnings', 'highfive.newpr.HighfiveHandler.post_warnings'),
             ('add_labels', 'highfive.newpr.HighfiveHandler.add_labels'),
@@ -867,9 +875,7 @@ class TestNewPrFunction(TestNewPR):
         self.mocks['choose_reviewer'].assert_called_once_with(
             'repo-name', 'repo-owner', 'diff', 'prAuthor'
         )
-        self.mocks['welcome_msg'].assert_called_once_with(
-            'reviewUser', self.config
-        )
+        self.mocks['welcome_msg'].assert_called_once_with('reviewUser')
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
             'Welcome!', 'repo-owner', 'repo-name', '7'
@@ -929,9 +935,7 @@ class TestNewPrFunction(TestNewPR):
 
         self.assert_fixed_calls('foundReviewer', None)
         self.mocks['choose_reviewer'].assert_not_called()
-        self.mocks['welcome_msg'].assert_called_once_with(
-            'foundReviewer', self.config
-        )
+        self.mocks['welcome_msg'].assert_called_once_with('foundReviewer')
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
             'Welcome!', 'repo-owner', 'repo-name', '7'
@@ -950,9 +954,7 @@ class TestNewPrFunction(TestNewPR):
 
         self.assert_fixed_calls('foundReviewer', None)
         self.mocks['choose_reviewer'].assert_not_called()
-        self.mocks['welcome_msg'].assert_called_once_with(
-            'foundReviewer', self.config
-        )
+        self.mocks['welcome_msg'].assert_called_once_with('foundReviewer')
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
             'Welcome!', 'repo-owner', 'repo-name', '7'

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -163,42 +163,45 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('highfive.newpr.api_req')
     def test_post_comment_success(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_api_req.return_value = {'body': 'response body!'}
         self.assertIsNone(
-            newpr.post_comment(
-                'Request body!', 'repo-owner', 'repo-name', 7, 'credential'
+            handler.post_comment(
+                'Request body!', 'repo-owner', 'repo-name', 7
             )
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/comments',
-            {'body': 'Request body!'}, 'credential'
+            {'body': 'Request body!'}, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
     def test_post_comment_error_201(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_api_req.return_value = {}
         mock_api_req.side_effect = HTTPError(None, 201, None, None, None)
         self.assertIsNone(
-            newpr.post_comment(
-                'Request body!', 'repo-owner', 'repo-name', 7, 'credential'
+            handler.post_comment(
+                'Request body!', 'repo-owner', 'repo-name', 7
             )
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/comments',
-            {'body': 'Request body!'}, 'credential'
+            {'body': 'Request body!'}, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
     def test_post_comment_error(self, mock_api_req):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_api_req.return_value = {}
         mock_api_req.side_effect = HTTPError(None, 422, None, None, None)
         self.assertRaises(
-            HTTPError, newpr.post_comment, 'Request body!', 'repo-owner',
-            'repo-name', 7, 'credential'
+            HTTPError, handler.post_comment, 'Request body!', 'repo-owner',
+            'repo-name', 7
         )
         mock_api_req.assert_called_with(
             'POST', 'https://api.github.com/repos/repo-owner/repo-name/issues/7/comments',
-            {'body': 'Request body!'}, 'credential'
+            {'body': 'Request body!'}, 'integrationToken'
         )
 
     @mock.patch('highfive.newpr.api_req')
@@ -545,7 +548,7 @@ class TestSetAssignee(TestNewPR):
         super(TestSetAssignee, self).setUp((
             ('api_req', 'highfive.newpr.api_req'),
             ('get_irc_nick', 'highfive.newpr.HighfiveHandler.get_irc_nick'),
-            ('post_comment', 'highfive.newpr.post_comment'),
+            ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
             ('IrcClient', 'highfive.irc.IrcClient'),
         ))
 
@@ -638,7 +641,7 @@ class TestSetAssignee(TestNewPR):
         self.mocks['client'].send_then_quit.assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
             'This is important\n\ncc @userA,@userB,@userC\n\nAlso important\n\ncc @userD',
-            self.owner, self.repo, self.issue, self.token
+            self.owner, self.repo, self.issue
         )
 
     def test_no_assignee(self):
@@ -723,7 +726,7 @@ class TestPostWarnings(TestNewPR):
         super(TestPostWarnings, self).setUp((
             ('unexpected_branch', 'highfive.newpr.HighfiveHandler.unexpected_branch'),
             ('modifies_submodule', 'highfive.newpr.HighfiveHandler.modifies_submodule'),
-            ('post_comment', 'highfive.newpr.post_comment'),
+            ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
         ))
 
         self.handler = HighfiveHandlerMock(
@@ -760,7 +763,7 @@ class TestPostWarnings(TestNewPR):
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!"""
         self.mocks['post_comment'].assert_called_with(
-            expected_warning, self.owner, self.repo, self.issue, self.token
+            expected_warning, self.owner, self.repo, self.issue
         )
 
     def test_modifies_submodule(self):
@@ -776,7 +779,7 @@ class TestPostWarnings(TestNewPR):
 
 * These commits modify **submodules**."""
         self.mocks['post_comment'].assert_called_with(
-            expected_warning, self.owner, self.repo, self.issue, self.token
+            expected_warning, self.owner, self.repo, self.issue
         )
 
     def test_unexpected_branch_modifies_submodule(self):
@@ -795,7 +798,7 @@ class TestPostWarnings(TestNewPR):
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
 * These commits modify **submodules**."""
         self.mocks['post_comment'].assert_called_with(
-            expected_warning, self.owner, self.repo, self.issue, self.token
+            expected_warning, self.owner, self.repo, self.issue
         )
 
 class TestNewPrFunction(TestNewPR):
@@ -816,7 +819,7 @@ class TestNewPrFunction(TestNewPR):
             ('choose_reviewer', 'highfive.newpr.HighfiveHandler.choose_reviewer'),
             ('set_assignee', 'highfive.newpr.HighfiveHandler.set_assignee'),
             ('is_new_contributor', 'highfive.newpr.HighfiveHandler.is_new_contributor'),
-            ('post_comment', 'highfive.newpr.post_comment'),
+            ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
             ('welcome_msg', 'highfive.newpr.welcome_msg'),
             ('review_msg', 'highfive.newpr.review_msg'),
             ('post_warnings', 'highfive.newpr.HighfiveHandler.post_warnings'),
@@ -867,7 +870,7 @@ class TestNewPrFunction(TestNewPR):
         )
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
-            'Welcome!', 'repo-owner', 'repo-name', '7', self.token
+            'Welcome!', 'repo-owner', 'repo-name', '7'
         )
         self.mocks['add_labels'].assert_called_once_with(
             'repo-owner', 'repo-name', '7'
@@ -892,7 +895,7 @@ class TestNewPrFunction(TestNewPR):
             'reviewUser', 'prAuthor'
         )
         self.mocks['post_comment'].assert_called_once_with(
-            'Review message!', 'repo-owner', 'repo-name', '7', self.token
+            'Review message!', 'repo-owner', 'repo-name', '7'
         )
         self.mocks['add_labels'].assert_called_once_with(
             'repo-owner', 'repo-name', '7'
@@ -929,7 +932,7 @@ class TestNewPrFunction(TestNewPR):
         )
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
-            'Welcome!', 'repo-owner', 'repo-name', '7', self.token
+            'Welcome!', 'repo-owner', 'repo-name', '7'
         )
         self.mocks['add_labels'].assert_not_called()
 
@@ -950,7 +953,7 @@ class TestNewPrFunction(TestNewPR):
         )
         self.mocks['review_msg'].assert_not_called()
         self.mocks['post_comment'].assert_called_once_with(
-            'Welcome!', 'repo-owner', 'repo-name', '7', self.token
+            'Welcome!', 'repo-owner', 'repo-name', '7'
         )
         self.mocks['add_labels'].assert_not_called()
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -354,8 +354,9 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('highfive.newpr.urllib2')
     def test_get_irc_nick_non_200(self, mock_urllib2):
+        handler = HighfiveHandlerMock(Payload({})).handler
         self.setup_get_irc_nick_mocks(mock_urllib2, 503)
-        self.assertIsNone(newpr.get_irc_nick('foo'))
+        self.assertIsNone(handler.get_irc_nick('foo'))
 
         mock_urllib2.urlopen.assert_called_with(
             'http://www.ncameron.org/rustaceans/user?username=foo'
@@ -363,8 +364,9 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('highfive.newpr.urllib2')
     def test_get_irc_nick_no_data(self, mock_urllib2):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_data = self.setup_get_irc_nick_mocks(mock_urllib2, 200, '[]')
-        self.assertIsNone(newpr.get_irc_nick('foo'))
+        self.assertIsNone(handler.get_irc_nick('foo'))
 
         mock_urllib2.urlopen.assert_called_with(
             'http://www.ncameron.org/rustaceans/user?username=foo'
@@ -374,11 +376,12 @@ Please see [the contribution instructions](%s) for more information.
 
     @mock.patch('highfive.newpr.urllib2')
     def test_get_irc_nick_has_data(self, mock_urllib2):
+        handler = HighfiveHandlerMock(Payload({})).handler
         mock_data = self.setup_get_irc_nick_mocks(
             mock_urllib2, 200,
             '[{"username":"nrc","name":"Nick Cameron","irc":"nrc","email":"nrc@ncameron.org","discourse":"nrc","reddit":"nick29581","twitter":"@nick_r_cameron","blog":"https://www.ncameron.org/blog","website":"https://www.ncameron.org","notes":"<p>I work on the Rust compiler, language design, and tooling. I lead the dev tools team and am part of the core team. I&#39;m part of the research team at Mozilla.</p>\\n","avatar":"https://avatars.githubusercontent.com/nrc","irc_channels":["rust-dev-tools","rust","rust-internals","rust-lang","rustc","servo"]}]'
         )
-        self.assertEqual(newpr.get_irc_nick('nrc'), 'nrc')
+        self.assertEqual(handler.get_irc_nick('nrc'), 'nrc')
 
         mock_urllib2.urlopen.assert_called_with(
             'http://www.ncameron.org/rustaceans/user?username=nrc'
@@ -541,7 +544,7 @@ class TestSetAssignee(TestNewPR):
     def setUp(self):
         super(TestSetAssignee, self).setUp((
             ('api_req', 'highfive.newpr.api_req'),
-            ('get_irc_nick', 'highfive.newpr.get_irc_nick'),
+            ('get_irc_nick', 'highfive.newpr.HighfiveHandler.get_irc_nick'),
             ('post_comment', 'highfive.newpr.post_comment'),
             ('IrcClient', 'highfive.irc.IrcClient'),
         ))

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -270,11 +270,12 @@ Please see [the contribution instructions](%s) for more information.
         )
 
     def test_submodule(self):
+        handler = HighfiveHandlerMock(Payload({})).handler
         submodule_diff = self._load_fake('submodule.diff')
-        self.assertTrue(newpr.modifies_submodule(submodule_diff))
+        self.assertTrue(handler.modifies_submodule(submodule_diff))
 
         normal_diff = self._load_fake('normal.diff')
-        self.assertFalse(newpr.modifies_submodule(normal_diff))
+        self.assertFalse(handler.modifies_submodule(normal_diff))
 
     def test_expected_branch_default_expected_no_match(self):
         payload = Payload(
@@ -715,7 +716,7 @@ class TestPostWarnings(TestNewPR):
     def setUp(self):
         super(TestPostWarnings, self).setUp((
             ('unexpected_branch', 'highfive.newpr.HighfiveHandler.unexpected_branch'),
-            ('modifies_submodule', 'highfive.newpr.modifies_submodule'),
+            ('modifies_submodule', 'highfive.newpr.HighfiveHandler.modifies_submodule'),
             ('post_comment', 'highfive.newpr.post_comment'),
         ))
 


### PR DESCRIPTION
_What:_ This PR reorganizes the functions in newpr.py into a class. This results in a large, not-so-simple-to-read diff.

_Why:_ Highfive functions use different pieces of shared state, such as the GitHub webhook token and the request payload. In the current design this state needs to be threaded through the functions to wherever it is used. The most common case of this is the webhook token, since calling the GitHub API tends to be at the bottom of the call stack. By reorganizing into a class we can avoid explicitly passing the state around, and it will make it easier and safer to add new features that depend on shared state.

Here's a summary of the interesting changes.
- The changes in newpr.py were primarily:
  1. Pulling functions into the class.
  1. Updating function calls to add `self.` and removing now-nonexistent arguments.
- The changes in test_newpr.py were to update tests for the new code organization. A mock class was added that many of the tests now use.
- The changes in integration_tests.py were to update tests for the new code organization. A couple new integration tests were added to address gaps.

_Risk:_ It's possible that some function-to-function calls were accidentally not updated. This would not be caught by the unit tests, but it would be caught by integration tests. Highfive's integration tests are less comprehensive than its unit tests. In addition to the test code, I manually tested the changes on a test repo.

The PR is being opened with discrete commits since that may be helpful in some way. Feel free to squash when merging!