### PR TITLE
Add Dockerfile and other associated files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apache2 \
+  ca-certificates \
+  python
+
+# Set up Highfive
+RUN mkdir /highfive
+WORKDIR /highfive
+
+COPY setup.py .
+COPY highfive/*.py highfive/
+COPY highfive/configs/* highfive/configs/
+RUN python setup.py install
+RUN touch highfive/config
+RUN chown -R www-data:www-data .
+
+# Set up Apache
+WORKDIR /etc/apache2
+COPY deployment/highfive.conf conf-available/highfive.conf
+RUN a2enmod cgi
+RUN rm conf-enabled/serve-cgi-bin.conf
+RUN rm sites-enabled/*
+RUN ln -s ../conf-available/highfive.conf conf-enabled
+
+EXPOSE 80
+CMD apachectl -D FOREGROUND

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ Here are some details to be aware of:
 
 [rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
 
+Docker
+------
+
+Alternatively, you can build a Docker image that runs Highfive.
+
+    $ docker build -t highfive .
+
+To run a container, you must mount a config file. Assuming you are
+launching a container from a directory containing a config file, you
+can do the following.
+
+    $ docker run -d --rm --name highfive -p 8080:80 -v $(pwd)/config:/highfive/highfive/config highfive
+
+At this point, Highfive is accessible at http://localhost:8080.
+
 License
 =======
 

--- a/deployment/highfive.conf
+++ b/deployment/highfive.conf
@@ -1,0 +1,7 @@
+SetEnv PYTHONPATH /highfive
+ScriptAlias /highfive/ /highfive/highfive/
+<Directory "/highfive">
+    AllowOverride None
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    Require all granted
+</Directory>


### PR DESCRIPTION
This PR makes it possible to run Highfive in a Docker container. This approach does not include an encrypted config file, as discussed in #165. To run this container, the config file needs to be mounted, like so:
```
$ docker run -d --rm --name highfive -p 8080:80 -v $(pwd)/config:/highfive/highfive/config highfive
```

I have verified the image builds a viable Highfive by testing with my Highfive test repo.