### PR TITLE
Always load repo config and bail on requests from unsupported repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,6 @@ your local instance. Here is one approach for running a local server:
 
 Here are some details to be aware of:
 
-- The beginning of `choose_reviewer` in
-  [highfive/newpr.py](/highfive/newpr.py) contains logic that causes
-  Highfive to ignore requests from unqualified repositories. You will
-  likely need to modify this logic in order for your local Highfive to
-  take action on new PRs.
 - For Highfive to know how to select reviewers for your repository,
   you need a configuration file in
   [highfive/configs](/highfive/configs).


### PR DESCRIPTION
Highfive currently handles requests from unsupported repositories. It doesn't actually do anything, but that is due to a filter later in the code that checks the repo org or for certain other special cases. Changes:
- Always load the repository configuration. This is currently only done for new PRs in the master branch.
- The way that Highfive is determining the repository name was modified. The current way in master only works for new PRs. The new way is present in new PR and new comment payloads.
- Bails out if the webhook request comes from an unsupported repository.
- Removes the logic that currently filters out requests from most unsupported repositories.
- Updates relevant tests.

Proposing this change was actually motivated by the filtering logic. In order to do local development on a non-Rust repository (which I do), the filter logic has to be modified. It's nicer to just not need to do that, and as a bonus, the benefits of not attempting to service unsupported repositories at all are nice.