### PR TITLE
Document mentions configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,22 @@ To make rust-highfive interact with a new repo, add a configuration file in
     },
     "contributing": "http://project.tld/contributing_guide.html",
     "expected_branch": "develop",
+    "mentions": {
+        "src/doc": {
+            "message": "Documentation was changed.",
+            "reviewers": ["@DocumentationReviewPerson"]
+        },
+        "test.rs": {
+            "message": "Some changes occurred in a test file.",
+            "reviewers": ["@TestReviewPerson"]
+        }
+    },
     "new_pr_labels": ["S-waiting-for-review"]
 }
 ```
 
 The `groups` section allows you to alias lists of usernames. You should
-specify at least one user in the group "all". Others are optional.
+specify at least one user in the group "all". Other keys are optional.
 
 In the `dirs` section, you map directories of the repository to users or
 groups who're eligible to review PRs. This section can be left
@@ -98,6 +108,16 @@ If PRs should be filed against a branch other than `master`, specify the
 correct destination in the `expected_branch` field. If `expected_branch` is
 left out, highfive will assume that PRs should be filed against `master`. 
 The bot posts a warning on any PR that targets an unexpected branch.
+
+The `mentions` section is used by Highfive when new PRs are
+created. If a PR diff modifies files in the paths configured in the
+`mentions` section, a comment is made with the given message that
+mentions the specified users. Mentions paths have either one or two
+behaviors.
+- Every path in a diff is checked whether it begins with a path in the
+  mentions list. If there is a match, the mention comment is made.
+- If a path in the diff ends with a mentions path ending in `.rs`, the
+  mention is a match, and a comment is made.
 
 `new_pr_labels` contains a list of labels to apply to each new PR. If it's left
 out or empty, no new labels will be applied.


### PR DESCRIPTION
This PR add documentation for the `mentions` key in repo configurations. Until this is merged a live version of these changes can be see [here](https://github.com/davidalber/highfive/tree/mention-mentions#adding-a-project).