### PR TITLE
Hide backtraces from the browser and store them on disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,7 @@ RUN rm conf-enabled/serve-cgi-bin.conf
 RUN rm sites-enabled/*
 RUN ln -s ../conf-available/highfive.conf conf-enabled
 
+RUN mkdir /var/log/highfive-tracebacks && chown www-data: /var/log/highfive-tracebacks
+
 EXPOSE 80
 CMD apachectl -D FOREGROUND

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -424,7 +424,7 @@ if __name__ == "__main__":
     print "Content-Type: text/html;charset=utf-8"
     print
 
-    cgitb.enable()
+    cgitb.enable(display=0, logdir="/var/log/highfive-tracebacks", format="txt")
 
     post = cgi.FieldStorage()
     payload_raw = post.getfirst("payload",'')


### PR DESCRIPTION
This will avoid us possibly leaking secret keys with a properly crafted payload.

cc @aidanhs 