### PR TITLE
Add NYAER repository

### DIFF
--- a/highfive/configs/rust-embedded/not-yet-awesome-embedded-rust.json
+++ b/highfive/configs/rust-embedded/not-yet-awesome-embedded-rust.json
@@ -1,0 +1,6 @@
+{
+    "groups": {
+        "all": ["rust-embedded/resources"]
+    },
+    "new_pr_labels": ["S-waiting-on-review", "T-resources"]
+}


### PR DESCRIPTION
This adds the Embedded-WG's https://github.com/rust-embedded/not-yet-awesome-embedded-rust repo to the list of High Five projects.

Let me know if I've missed anything that needs to be updated :)