### PR TITLE
temporarily remove japaric from most highfive rotations

### DIFF
--- a/highfive/configs/_global.json
+++ b/highfive/configs/_global.json
@@ -3,11 +3,11 @@
         "core": ["@nikomatsakis", "@alexcrichton"],
         "crates": ["@alexcrichton"],
         "doc": ["@steveklabnik", "@GuillaumeGomez", "@frewsxcv", "@QuietMisdreavus"],
-        "rust-embedded/cortex-m": ["@adamgreig", "@ithinuel", "@japaric", "@korken89", "@thejpster", "@therealprof"],
+        "rust-embedded/cortex-m": ["@adamgreig", "@ithinuel", "@korken89", "@thejpster", "@therealprof"],
         "rust-embedded/cortex-r": ["@japaric", "@paoloteti"],
         "rust-embedded/embedded-linux": ["@posborne", "@nastevens"],
-        "rust-embedded/hal": ["@hannobraun", "@ryankurte", "@thejpster", "@therealprof", "@ithinuel", "@japaric"],
+        "rust-embedded/hal": ["@hannobraun", "@ryankurte", "@thejpster", "@therealprof", "@ithinuel"],
         "rust-embedded/infrastructure": ["@ryankurte", "@nastevens"],
-        "rust-embedded/resources": ["@adamgreig", "@andre-richter", "@jamesmunns", "@japaric", "@korken89", "@ryankurte", "@thejpster", "@therealprof"]
+        "rust-embedded/resources": ["@adamgreig", "@andre-richter", "@jamesmunns", "@korken89", "@ryankurte", "@thejpster", "@therealprof"]
     }
 }

--- a/highfive/configs/rust-embedded/cross.json
+++ b/highfive/configs/rust-embedded/cross.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@DylanDPC", "@jamesmunns", "@japaric"]
+        "all": ["@DylanDPC", "@jamesmunns"]
     },
     "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
I won't have bandwidth for reviews for the next few months due to my thesis work but I'll eventually get back to it.